### PR TITLE
fix: remove colors from logs

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -17,11 +17,7 @@ async function bootstrap() {
   winston.add(
     new winston.transports.Console({
       level: 'debug',
-      format: format.combine(
-        format.colorize({ all: true }),
-        format.splat(),
-        format.simple(),
-      ),
+      format: format.combine(format.splat(), format.simple()),
     }),
   );
 


### PR DESCRIPTION
Fixes #36 

The PR simply configures our logging library to not colorize the logs.