### PR TITLE
feat: return `limit` in remaing relay response

### DIFF
--- a/src/routes/relay/relay.controller.spec.ts
+++ b/src/routes/relay/relay.controller.spec.ts
@@ -729,6 +729,7 @@ describe('RelayController', () => {
           .expect(200)
           .expect((res) => {
             expect(res.body).toStrictEqual({
+              limit: 5,
               remaining: 4,
               expiresAt: expect.any(Number),
             });
@@ -757,6 +758,7 @@ describe('RelayController', () => {
           .expect(200)
           .expect((res) => {
             expect(res.body).toStrictEqual({
+              limit: 5,
               remaining: 4,
               expiresAt: expect.any(Number),
             });
@@ -795,6 +797,7 @@ describe('RelayController', () => {
               .expect(200)
               .expect((res) => {
                 expect(res.body).toStrictEqual({
+                  limit: 5,
                   remaining: 4,
                   expiresAt: expect.any(Number),
                 });
@@ -833,6 +836,7 @@ describe('RelayController', () => {
           .expect(200)
           .expect((res) => {
             expect(res.body).toStrictEqual({
+              limit: 5,
               remaining: 0,
               expiresAt: expect.any(Number),
             });

--- a/src/routes/relay/services/relay-limit.service.ts
+++ b/src/routes/relay/services/relay-limit.service.ts
@@ -33,6 +33,7 @@ export class RelayLimitService {
     chainId: string,
     address: string,
   ): {
+    limit: number;
     remaining: number;
     expiresAt?: number;
   } {
@@ -42,6 +43,7 @@ export class RelayLimitService {
     };
 
     return {
+      limit: this.limit,
       remaining: Math.max(0, this.limit - throttlerEntry.totalHits),
       expiresAt: throttlerEntry.expiresAt,
     };


### PR DESCRIPTION
This adds the global `limit` of relays to the remaining relay endpoint, now returning:

```ts
{
  limit: number,
  remaining: number,
  expiresAt: number
}