### PR TITLE
feat: add alerts to errors we want to monitor

### DIFF
--- a/src/middleware/logger.middleware.ts
+++ b/src/middleware/logger.middleware.ts
@@ -17,15 +17,14 @@ export class LoggerMiddleware implements NestMiddleware {
     const contentLength = res.get('content-length') || '';
     const contentType = res.get('content-type') || '';
 
-    const responseMessage: [string, number, string, string] = [
-      '[<==] %d %s %s',
-      res.statusCode,
-      contentLength,
-      contentType,
-    ];
-
     res.on('finish', () => {
       const { statusCode } = res;
+      const responseMessage: [string, number, string, string] = [
+        '[<==] %d %s %s',
+        res.statusCode,
+        contentLength,
+        contentType,
+      ];
       if (statusCode < 400) {
         this.loggingService.log(...responseMessage);
       } else if (statusCode >= 400 && statusCode < 500) {

--- a/src/routes/relay/relay.service.ts
+++ b/src/routes/relay/relay.service.ts
@@ -32,7 +32,7 @@ export class RelayService {
     // Check rate limit is not reached
     if (!this.relayLimitService.canRelay(chainId, limitAddresses)) {
       this.loggingService.error(
-        'Transaction could not be relayed because the relay limit was reached.',
+        'Transaction can not be relayed because the address relay limit was reached.',
       );
       throw new HttpException(
         'Relay limit reached',

--- a/src/routes/relay/relay.service.ts
+++ b/src/routes/relay/relay.service.ts
@@ -7,12 +7,17 @@ import {
   SponsorService,
 } from '../../datasources/sponsor/sponsor.service.interface';
 import { RelayResponse } from '@gelatonetwork/relay-sdk';
+import {
+  ILoggingService,
+  LoggingService,
+} from '../common/logging/logging.interface';
 
 @Injectable()
 export class RelayService {
   constructor(
     private readonly relayLimitService: RelayLimitService,
     @Inject(SponsorService) private readonly sponsorService: ISponsorService,
+    @Inject(LoggingService) private readonly loggingService: ILoggingService,
   ) {}
 
   /**
@@ -26,6 +31,9 @@ export class RelayService {
 
     // Check rate limit is not reached
     if (!this.relayLimitService.canRelay(chainId, limitAddresses)) {
+      this.loggingService.error(
+        'Transaction could not be relayed because the relay limit was reached.',
+      );
       throw new HttpException(
         'Relay limit reached',
         HttpStatus.TOO_MANY_REQUESTS,
@@ -38,6 +46,10 @@ export class RelayService {
       // Relay
       response = await this.sponsorService.sponsoredCall(sponsoredCallDto);
     } catch (err) {
+      this.loggingService.error(
+        'Unexpected error from Gelato sponsored call: `%s`',
+        err,
+      );
       throw new HttpException('Relay failed', HttpStatus.INTERNAL_SERVER_ERROR);
     }
 


### PR DESCRIPTION
Adds two alerts / error logs:
- Unexpected errors during the `sponsoredCall`
- Transaction relay attempts despite reached relay limit

