### PR TITLE
fix: `uncolorize` logs

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -17,7 +17,11 @@ async function bootstrap() {
   winston.add(
     new winston.transports.Console({
       level: 'debug',
-      format: format.combine(format.splat(), format.simple()),
+      format: format.combine(
+        format.uncolorize(),
+        format.splat(),
+        format.simple(),
+      ),
     }),
   );
 


### PR DESCRIPTION
Resolves #36 and removes all colours from `winston` logs [via `uncolorize`](https://github.com/winstonjs/logform#uncolorize).