### PR TITLE
chore: Deploy release to dockerhub

### DIFF
--- a/scripts/deploy_docker.sh
+++ b/scripts/deploy_docker.sh
@@ -16,26 +16,13 @@ else
     cache_tag="staging"
 fi
 
-cached_builder_image_id="$DOCKERHUB_ORG/$DOCKERHUB_PROJECT:$cache_tag-builder"
 cached_runtime_image_id="$DOCKERHUB_ORG/$DOCKERHUB_PROJECT:$cache_tag"
 runtime_image_id="$DOCKERHUB_ORG/$DOCKERHUB_PROJECT:$1"
-
-# Load cached builder image
-docker pull $cached_builder_image_id || true
-# Rebuild builder image if required
-docker build \
-    --target builder \
-    --cache-from $cached_builder_image_id \
-    -t $cached_builder_image_id \
-    -f Dockerfile \
-    --build-arg VERSION --build-arg BUILD_NUMBER \
-    .
 
 # Load cached runtime image
 docker pull $cached_runtime_image_id || true
 # Rebuild runtime image if required
 docker build \
-    --cache-from $cached_builder_image_id \
     --cache-from $cached_runtime_image_id \
     -t $runtime_image_id \
     -f Dockerfile \
@@ -44,9 +31,6 @@ docker build \
 
 # Push runtime images to remote repository
 docker push $runtime_image_id
-
-# Push builder image to remote repository for next build
-docker push $cached_builder_image_id
 
 # If release, set latest docker tag
 case $1 in v*)


### PR DESCRIPTION
## What it solves

- Removes the builder cache and uses the staging image instead