### PR TITLE
chore: Deploy to dockerhub on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   push:
   pull_request:
+  release:
+    types: [ released ]
 
 jobs:
   prettier:
@@ -67,7 +69,7 @@ jobs:
           cache-to: type=inline
 
   docker-publish:
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'release' && github.event.action == 'released'
     needs: [ prettier, es-lint, tests ]
     runs-on: ubuntu-latest
     steps:
@@ -81,12 +83,12 @@ jobs:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - uses: docker/build-push-action@v3
-        env:
-          DOCKER_IMAGE_TAG: safeglobal/safe-gelato-relay-service:${GITHUB_REF##*/},safeglobal/safe-gelato-relay-service:latest
         with:
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ env.DOCKER_IMAGE_TAG }}
+          tags: |
+            safeglobal/safe-gelato-relay-service:${{ github.event.release.tag_name }}
+            safeglobal/safe-gelato-relay-service:latest
           # Use inline cache storage https://docs.docker.com/build/cache/backends/inline/
           cache-from: type=registry,ref=safeglobal/safe-gelato-relay-service:staging
           cache-to: type=inline


### PR DESCRIPTION
## What it solves

- Deploys to docker hub when a release is created instead of tag push