### PR TITLE
Add AppProvider

### DIFF
--- a/src/app.module.spec.ts
+++ b/src/app.module.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 
 import { AppModule } from './app.module';
+import { TestAppProvider } from './app.provider';
 
 describe('Application bootstrap', () => {
   it('Should init the app', async () => {
@@ -8,7 +9,7 @@ describe('Application bootstrap', () => {
       imports: [AppModule],
     }).compile();
 
-    const app = moduleFixture.createNestApplication();
+    const app = await new TestAppProvider().provide(moduleFixture);
 
     await app.init();
     expect(app).toBeDefined();

--- a/src/app.provider.ts
+++ b/src/app.provider.ts
@@ -46,13 +46,13 @@ export abstract class AppProvider {
     (app: INestApplication) => void
   >;
 
-  public async provide(module: any): Promise<INestApplication> {
+  public async provide(module: unknown): Promise<INestApplication> {
     const app = await this.getApp(module);
     this.configuration.forEach((f) => f(app));
     return app;
   }
 
-  protected abstract getApp(module: any): Promise<INestApplication>;
+  protected abstract getApp(module: unknown): Promise<INestApplication>;
 }
 
 /**
@@ -65,7 +65,7 @@ export class DefaultAppProvider extends AppProvider {
   protected readonly configuration: Array<(app: INestApplication) => void> =
     DEFAULT_CONFIGURATION;
 
-  protected getApp(module: any): Promise<INestApplication> {
+  protected getApp(module: unknown): Promise<INestApplication> {
     return NestFactory.create(module);
   }
 }
@@ -88,11 +88,9 @@ export class TestAppProvider extends AppProvider {
     }
   }
 
-  protected getApp(module: any): Promise<INestApplication> {
+  protected getApp(module: unknown): Promise<INestApplication> {
     if (!(module instanceof TestingModule))
-      return Promise.reject(
-        `${module.constructor.name} is not a TestingModule`,
-      );
+      return Promise.reject(`Provided module is not a TestingModule`);
     return Promise.resolve(module.createNestApplication());
   }
 }

--- a/src/app.provider.ts
+++ b/src/app.provider.ts
@@ -1,0 +1,98 @@
+import { INestApplication, VersioningType } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+import { TestingModule } from '@nestjs/testing/testing-module';
+import * as winston from 'winston';
+import { format } from 'winston';
+
+function configureLogger() {
+  winston.add(
+    new winston.transports.Console({
+      level: 'debug',
+      format: format.combine(format.splat(), format.simple()),
+    }),
+  );
+}
+
+function configureVersioning(app: INestApplication) {
+  app.enableVersioning({
+    type: VersioningType.URI,
+  });
+}
+
+function configureCors(app: INestApplication) {
+  app.enableCors({
+    origin: '*',
+  });
+}
+
+const DEFAULT_CONFIGURATION: ((app: INestApplication) => void)[] = [
+  configureLogger,
+  configureVersioning,
+  configureCors,
+];
+
+/**
+ * The main goal of {@link AppProvider} is to provide
+ * a {@link INestApplication}.
+ *
+ * Extensions of this class should return the application in
+ * {@link getApp}.
+ *
+ * Each provider should have a {@link configuration} which specifies
+ * the steps taken to configure the application
+ */
+export abstract class AppProvider {
+  protected abstract readonly configuration: Array<
+    (app: INestApplication) => void
+  >;
+
+  public async provide(module: any): Promise<INestApplication> {
+    const app = await this.getApp(module);
+    this.configuration.forEach((f) => f(app));
+    return app;
+  }
+
+  protected abstract getApp(module: any): Promise<INestApplication>;
+}
+
+/**
+ * The default {@link AppProvider}
+ *
+ * This provider should be used to retrieve the actual implementation of the
+ * service
+ */
+export class DefaultAppProvider extends AppProvider {
+  protected readonly configuration: Array<(app: INestApplication) => void> =
+    DEFAULT_CONFIGURATION;
+
+  protected getApp(module: any): Promise<INestApplication> {
+    return NestFactory.create(module);
+  }
+}
+
+/**
+ * A test {@link AppProvider}
+ *
+ * This provider provides an application given a {@link TestingModule}
+ *
+ * If the module provided is not a {@link TestingModule}, an error is thrown
+ */
+export class TestAppProvider extends AppProvider {
+  protected readonly configuration: Array<(app: INestApplication) => void> =
+    DEFAULT_CONFIGURATION;
+
+  constructor() {
+    super();
+    if (process.env.NODE_ENV !== 'test') {
+      throw Error('TestAppProvider used outside of a testing environment');
+    }
+  }
+
+  protected getApp(module: any): Promise<INestApplication> {
+    if (!(module instanceof TestingModule))
+      return Promise.reject(
+        `${module.constructor.name} is not a TestingModule`,
+      );
+    return Promise.resolve(module.createNestApplication());
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,24 +1,12 @@
 import { ConfigService } from '@nestjs/config';
-import { NestFactory } from '@nestjs/core';
 
 import { AppModule } from './app.module';
-import * as winston from 'winston';
-import { format } from 'winston';
+import { DefaultAppProvider } from './app.provider';
+import { INestApplication } from '@nestjs/common';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
-  app.enableVersioning();
-
-  // TODO: Define cors headers which we want to allow.
-  app.enableCors({
-    origin: '*',
-  });
-
-  winston.add(
-    new winston.transports.Console({
-      level: 'debug',
-      format: format.combine(format.splat(), format.simple()),
-    }),
+  const app: INestApplication = await new DefaultAppProvider().provide(
+    AppModule,
   );
 
   const configService = app.get(ConfigService);
@@ -26,4 +14,5 @@ async function bootstrap() {
 
   await app.listen(port);
 }
+
 bootstrap();

--- a/src/routes/relay/relay.controller.spec.ts
+++ b/src/routes/relay/relay.controller.spec.ts
@@ -15,10 +15,10 @@ import { ethers } from 'ethers';
 import { RelayModule } from './relay.module';
 import { SupportedChainId } from '../../config/constants';
 import {
+  getMockCreateProxyWithNonceCalldata,
   getMockExecTransactionCalldata,
   getMockMultiSendCalldata,
   MOCK_UNSUPPORTED_CALLDATA,
-  getMockCreateProxyWithNonceCalldata,
 } from '../../__mocks__/transaction-calldata.mock';
 import { TestLoggingModule } from '../common/logging/__tests__/test.logging.module';
 import { TestSponsorModule } from '../../datasources/sponsor/__tests__/test.sponsor.module';
@@ -31,6 +31,7 @@ import {
   ISafeInfoService,
   SafeInfoService,
 } from '../../datasources/safe-info/safe-info.service.interface';
+import { TestAppProvider } from '../../app.provider';
 
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const GOERLI_MULTI_SEND_CALL_ONLY_ADDRESS = getMultiSendCallOnlyDeployment({
@@ -102,8 +103,7 @@ describe('RelayController', () => {
     mockSponsorService = moduleFixture.get<ISponsorService>(SponsorService);
     mockSafeInfoService = moduleFixture.get<ISafeInfoService>(SafeInfoService);
 
-    app = moduleFixture.createNestApplication();
-    app.enableVersioning();
+    app = await new TestAppProvider().provide(moduleFixture);
 
     await app.init();
   });


### PR DESCRIPTION
- Adds `AppProvider` – this is an abstraction that encapsulates the application creation and respective setup
- There are two implementations:
  * `DefaultAppProvider` – is the default application instance and should be the one used for normal application instantiation
  * `TestAppProvider` – provides application instance given a `TestingModule` – providing any other module would result in a rejected `Promise`
- These two implementation share the same setup steps – this allows us to write tests that will use the same configuration applied in the production instance. The configuration steps are set under `DEFAULT_CONFIGURATION`. This configuration is provided to the instances so that it can be changed (e.g. a testing instance might want to remove a configuration step)