### PR TITLE
Fix dependabot package-ecosystem value

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 
 updates:
-  - package-ecosystem: "yarn"
+  - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
- `yarn` was incorrectly set as a value of `package-ecosystem`. `npm` should be used instead