### PR TITLE
Use info level to log route requests

### DIFF
--- a/src/middleware/logger.middleware.ts
+++ b/src/middleware/logger.middleware.ts
@@ -12,7 +12,7 @@ export class LoggerMiddleware implements NestMiddleware {
   ) {}
 
   use(req: Request, res: Response, next: NextFunction) {
-    this.loggingService.debug?.('[==>] %s %s', req.method, req.url);
+    this.loggingService.info('[==>] %s %s', req.method, req.url);
 
     const contentLength = res.get('content-length') || '';
     const contentType = res.get('content-type') || '';
@@ -26,7 +26,7 @@ export class LoggerMiddleware implements NestMiddleware {
         contentType,
       ];
       if (statusCode < 400) {
-        this.loggingService.log(...responseMessage);
+        this.loggingService.info(...responseMessage);
       } else if (statusCode >= 400 && statusCode < 500) {
         this.loggingService.warn(...responseMessage);
       } else {

--- a/src/routes/common/logging/__tests__/test.logging.module.ts
+++ b/src/routes/common/logging/__tests__/test.logging.module.ts
@@ -2,7 +2,7 @@ import { Global, Module } from '@nestjs/common';
 import { ILoggingService, LoggingService } from '../logging.interface';
 
 const loggerService: ILoggingService = {
-  log: console.log,
+  info: console.log,
   error: console.error,
   warn: console.warn,
   debug: console.debug,

--- a/src/routes/common/logging/logging.interface.ts
+++ b/src/routes/common/logging/logging.interface.ts
@@ -1,7 +1,7 @@
 export const LoggingService = Symbol('ILoggingService');
 
 export interface ILoggingService {
-  log(message: string, ...optionalParams: unknown[]): void;
+  info(message: string, ...optionalParams: unknown[]): void;
   debug(message: string, ...optionalParams: unknown[]): void;
   error(message: string, ...optionalParams: unknown[]): void;
   warn(message: string, ...optionalParams: unknown[]): void;

--- a/src/routes/common/logging/logging.service.spec.ts
+++ b/src/routes/common/logging/logging.service.spec.ts
@@ -32,7 +32,8 @@ describe('RequestScopedLoggingService', () => {
 
   it('log', () => {
     const message = 'Some message';
-    loggingService.log(message);
+
+    loggingService.info(message);
 
     expect(infoMock).toHaveBeenCalledTimes(1);
     expect(infoMock).toHaveBeenCalledWith(
@@ -42,6 +43,7 @@ describe('RequestScopedLoggingService', () => {
 
   it('error', () => {
     const message = 'Some message';
+
     loggingService.error(message);
 
     expect(errorMock).toHaveBeenCalledTimes(1);
@@ -52,6 +54,7 @@ describe('RequestScopedLoggingService', () => {
 
   it('warn', () => {
     const message = 'Some message';
+
     loggingService.warn(message);
 
     expect(warnMock).toHaveBeenCalledTimes(1);
@@ -62,6 +65,7 @@ describe('RequestScopedLoggingService', () => {
 
   it('debug', () => {
     const message = 'Some message';
+
     loggingService.debug(message);
 
     expect(debugMock).toHaveBeenCalledTimes(1);

--- a/src/routes/common/logging/logging.service.ts
+++ b/src/routes/common/logging/logging.service.ts
@@ -11,15 +11,19 @@ import { ILoggingService } from './logging.interface';
 @Injectable()
 export class RequestScopedLoggingService implements ILoggingService {
   constructor(private readonly cls: ClsService) {}
-  log(message: string, ...optionalParams: unknown[]) {
+
+  info(message: string, ...optionalParams: unknown[]) {
     winston.info(this.transformMessage(message), ...optionalParams);
   }
+
   error(message: string, ...optionalParams: unknown[]) {
     winston.error(this.transformMessage(message), ...optionalParams);
   }
+
   warn(message: string, ...optionalParams: unknown[]) {
     winston.warn(this.transformMessage(message), ...optionalParams);
   }
+
   debug(message: string, ...optionalParams: unknown[]) {
     winston.debug(this.transformMessage(message), ...optionalParams);
   }


### PR DESCRIPTION
- Uses `info` level instead of `debug` to log the requests that hit the service
- Use `winston.info` instead of `winston.log` – `log` relies on a configuration object (which has a set of defaults). However, when using the `RequestScopedLoggingService` we want to provide a strict-level API for logging.