### PR TITLE
Provide Winston instance in dependency graph

### DIFF
--- a/src/app.provider.ts
+++ b/src/app.provider.ts
@@ -1,17 +1,6 @@
 import { INestApplication, VersioningType } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { TestingModule } from '@nestjs/testing/testing-module';
-import * as winston from 'winston';
-import { format } from 'winston';
-
-function configureLogger() {
-  winston.add(
-    new winston.transports.Console({
-      level: 'debug',
-      format: format.combine(format.splat(), format.simple()),
-    }),
-  );
-}
 
 function configureVersioning(app: INestApplication) {
   app.enableVersioning({
@@ -26,7 +15,6 @@ function configureCors(app: INestApplication) {
 }
 
 const DEFAULT_CONFIGURATION: ((app: INestApplication) => void)[] = [
-  configureLogger,
   configureVersioning,
   configureCors,
 ];

--- a/src/routes/common/logging/logging.module.ts
+++ b/src/routes/common/logging/logging.module.ts
@@ -2,7 +2,6 @@ import { Global, Module } from '@nestjs/common';
 import { LoggingService } from './logging.interface';
 import { RequestScopedLoggingService } from './logging.service';
 import * as winston from 'winston';
-import { format } from 'winston';
 import * as Transport from 'winston-transport';
 
 /**
@@ -23,7 +22,10 @@ const LoggerTransports = Symbol('LoggerTransports');
 function winstonTransportsFactory(): Transport[] | Transport {
   return new winston.transports.Console({
     level: 'debug',
-    format: format.combine(format.splat(), format.simple()),
+    format: winston.format.combine(
+      winston.format.splat(),
+      winston.format.simple(),
+    ),
   });
 }
 

--- a/src/routes/common/logging/logging.service.spec.ts
+++ b/src/routes/common/logging/logging.service.spec.ts
@@ -6,37 +6,36 @@ const mockClsService = {
   getId: jest.fn(() => '123-456'),
 } as unknown as ClsService;
 
-jest.mock('winston');
+const mockLogger = {
+  info: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+  debug: jest.fn(),
+} as unknown as winston.Logger;
 
 describe('RequestScopedLoggingService', () => {
-  const infoMock = jest.fn();
-  const debugMock = jest.fn();
-  const errorMock = jest.fn();
-  const warnMock = jest.fn();
   let loggingService: RequestScopedLoggingService;
 
   beforeAll(() => {
     jest.useFakeTimers();
     jest.setSystemTime(new Date('2023-01-01'));
-    jest.spyOn(winston, 'info').mockImplementation(infoMock);
-    jest.spyOn(winston, 'debug').mockImplementation(debugMock);
-    jest.spyOn(winston, 'error').mockImplementation(errorMock);
-    jest.spyOn(winston, 'warn').mockImplementation(warnMock);
-
-    loggingService = new RequestScopedLoggingService(mockClsService);
   });
 
   beforeEach(() => {
     jest.clearAllMocks();
+    loggingService = new RequestScopedLoggingService(
+      mockLogger,
+      mockClsService,
+    );
   });
 
-  it('log', () => {
+  it('info', () => {
     const message = 'Some message';
 
     loggingService.info(message);
 
-    expect(infoMock).toHaveBeenCalledTimes(1);
-    expect(infoMock).toHaveBeenCalledWith(
+    expect(mockLogger.info).toHaveBeenCalledTimes(1);
+    expect(mockLogger.info).toHaveBeenCalledWith(
       `${new Date('2023-01-01').toISOString()} 123-456 - ${message}`,
     );
   });
@@ -46,8 +45,8 @@ describe('RequestScopedLoggingService', () => {
 
     loggingService.error(message);
 
-    expect(errorMock).toHaveBeenCalledTimes(1);
-    expect(errorMock).toHaveBeenCalledWith(
+    expect(mockLogger.error).toHaveBeenCalledTimes(1);
+    expect(mockLogger.error).toHaveBeenCalledWith(
       `${new Date('2023-01-01').toISOString()} 123-456 - ${message}`,
     );
   });
@@ -57,8 +56,8 @@ describe('RequestScopedLoggingService', () => {
 
     loggingService.warn(message);
 
-    expect(warnMock).toHaveBeenCalledTimes(1);
-    expect(warnMock).toHaveBeenCalledWith(
+    expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
       `${new Date('2023-01-01').toISOString()} 123-456 - ${message}`,
     );
   });
@@ -68,8 +67,8 @@ describe('RequestScopedLoggingService', () => {
 
     loggingService.debug(message);
 
-    expect(debugMock).toHaveBeenCalledTimes(1);
-    expect(debugMock).toHaveBeenCalledWith(
+    expect(mockLogger.debug).toHaveBeenCalledTimes(1);
+    expect(mockLogger.debug).toHaveBeenCalledWith(
       `${new Date('2023-01-01').toISOString()} 123-456 - ${message}`,
     );
   });

--- a/src/routes/common/logging/logging.service.ts
+++ b/src/routes/common/logging/logging.service.ts
@@ -1,7 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import { ClsService } from 'nestjs-cls';
-import * as winston from 'winston';
 import { ILoggingService } from './logging.interface';
+import { Inject } from '@nestjs/common/decorators';
+import winston from 'winston';
 
 /**
  * Implementation of LoggerService which prepends the current time and a unique request ID to every logged message.
@@ -10,22 +11,25 @@ import { ILoggingService } from './logging.interface';
  */
 @Injectable()
 export class RequestScopedLoggingService implements ILoggingService {
-  constructor(private readonly cls: ClsService) {}
+  constructor(
+    @Inject('Logger') private readonly logger: winston.Logger,
+    private readonly cls: ClsService,
+  ) {}
 
   info(message: string, ...optionalParams: unknown[]) {
-    winston.info(this.transformMessage(message), ...optionalParams);
+    this.logger.info(this.transformMessage(message), ...optionalParams);
   }
 
   error(message: string, ...optionalParams: unknown[]) {
-    winston.error(this.transformMessage(message), ...optionalParams);
+    this.logger.error(this.transformMessage(message), ...optionalParams);
   }
 
   warn(message: string, ...optionalParams: unknown[]) {
-    winston.warn(this.transformMessage(message), ...optionalParams);
+    this.logger.warn(this.transformMessage(message), ...optionalParams);
   }
 
   debug(message: string, ...optionalParams: unknown[]) {
-    winston.debug(this.transformMessage(message), ...optionalParams);
+    this.logger.debug(this.transformMessage(message), ...optionalParams);
   }
 
   private transformMessage(message: string): string {


### PR DESCRIPTION
- Provide a Winston instance through the dependency graph instead of relying on a globally provided one (under the winston package).
- No changes were made to the format and types of transport – configuration was just moved.
- Removes the logger configuration from the `AppProvider` since the logger instance is now provided in the `RequestScopedLoggingModule`