### PR TITLE
Add RouteLoggerInterceptor

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,7 +1,7 @@
 import { MiddlewareConsumer, Module, RequestMethod } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { v4 as uuidv4 } from 'uuid';
-import { ClsModule, ClsMiddleware } from 'nestjs-cls';
+import { ClsMiddleware, ClsModule } from 'nestjs-cls';
 
 import configuration from './config/configuration';
 import { NetworkModule } from './datasources/network/network.module';
@@ -10,6 +10,8 @@ import { LoggerMiddleware } from './middleware/logger.middleware';
 import { SponsorModule } from './datasources/sponsor/sponsor.module';
 import { RelayModule } from './routes/relay/relay.module';
 import { RequestScopedLoggingModule } from './routes/common/logging/logging.module';
+import { APP_INTERCEPTOR } from '@nestjs/core';
+import { RouteLoggerInterceptor } from './routes/common/interceptors/route-logger.interceptor';
 
 @Module({
   imports: [
@@ -32,6 +34,12 @@ import { RequestScopedLoggingModule } from './routes/common/logging/logging.modu
       },
     }),
     RequestScopedLoggingModule,
+  ],
+  providers: [
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: RouteLoggerInterceptor,
+    },
   ],
 })
 export class AppModule {

--- a/src/middleware/logger.middleware.ts
+++ b/src/middleware/logger.middleware.ts
@@ -12,19 +12,9 @@ export class LoggerMiddleware implements NestMiddleware {
   ) {}
 
   use(req: Request, res: Response, next: NextFunction) {
-    this.loggingService.info('[==>] %s %s', req.method, req.url);
-
-    const contentLength = res.get('content-length') || '';
-    const contentType = res.get('content-type') || '';
-
     res.on('finish', () => {
       const { statusCode } = res;
-      const responseMessage: [string, number, string, string] = [
-        '[<==] %d %s %s',
-        res.statusCode,
-        contentLength,
-        contentType,
-      ];
+      const responseMessage: [string, number] = ['[<==] %d', res.statusCode];
       if (statusCode < 400) {
         this.loggingService.info(...responseMessage);
       } else if (statusCode >= 400 && statusCode < 500) {

--- a/src/routes/common/interceptors/route-logger.interceptor.ts
+++ b/src/routes/common/interceptors/route-logger.interceptor.ts
@@ -1,0 +1,29 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { ILoggingService, LoggingService } from '../logging/logging.interface';
+import { Inject } from '@nestjs/common/decorators';
+
+/**
+ * The {@link RouteLoggerInterceptor} is an interceptor that logs the requests
+ * that target a specific route.
+ *
+ * Since this is an interceptor we have access to the respective {@link ExecutionContext}
+ * See https://docs.nestjs.com/fundamentals/execution-context
+ */
+@Injectable()
+export class RouteLoggerInterceptor implements NestInterceptor {
+  constructor(
+    @Inject(LoggingService) private readonly loggingService: ILoggingService,
+  ) {}
+
+  intercept(context: ExecutionContext, next: CallHandler) {
+    const req = context.switchToHttp().getRequest();
+    // TODO Use req.route.path to log the route path without any replacement
+    this.loggingService.info('[==>] %s %s', req.method, req.url);
+    return next.handle();
+  }
+}


### PR DESCRIPTION
- Adds `RouteLoggerInterceptor` – a NestJS interceptor which logs the requests that target each route
- Removes the request logging from the `LoggerMiddleware`
- The main reason for this change is that Middlewares are executed before the route handlers – this means that we lack context on which handler is going to be called at this stage. Interceptors however, have an `ExecutionContext` tied to it. Which means that at this point we have more information on the route that is going to be triggered.
- Removes the logging of `contentLength` and `contentType` since these were empty in the middleware (this needs to be reviewed internally, i.e. if and how we want to log these values)

For example if we trigger the relay route `GET /v1/relay/1/0x0`:

```
console.log(req.route.path)
"/*" // LoggerMiddleware
"/v1/relay/:chainId/:address" // RouteLoggerInterceptor
```