### PR TITLE
feat: prevent relaying of transactions to self

### DIFF
--- a/src/routes/relay/entities/schema/sponsored-call.schema.ts
+++ b/src/routes/relay/entities/schema/sponsored-call.schema.ts
@@ -4,7 +4,7 @@ import { AddressSchema } from '../../../common/schema/address.schema';
 import { ChainIdSchema } from '../../../common/schema/chain-id.schema';
 import {
   isValidMultiSendCall,
-  isExecTransactionCalldata,
+  isValidExecTransactionCall,
   getSafeAddressFromMultiSend,
   isValidCreateProxyWithNonceCall,
   getOwnersFromCreateProxyWithNonce,
@@ -31,7 +31,7 @@ export const SponsoredCallSchema = z
     };
 
     // `execTransaction`
-    if (isExecTransactionCalldata(data)) {
+    if (isValidExecTransactionCall(to, data)) {
       return {
         ...values,
         limitAddresses: [to],
@@ -61,7 +61,7 @@ export const SponsoredCallSchema = z
     }
 
     setError(
-      'Only Safe creation or (batched) Safe transactions can be relayed',
+      'Only Safe creation or (batched) Safe transactions not to self can be relayed',
     );
     return z.NEVER;
   });


### PR DESCRIPTION
This prevents `execTransaction` calls to self, unless they are a rejection transaction. It's implementation also prevents batches from their inclusion. Tests have been updated and added accordingly.

It has been tested working:

- blocking `execTransaction` _to_ self
- blocking batches including `execTransaction`s _to_ self
- allowing `execTransaction` _not_ to self
- allowing batches including `execTransaction`s _not_ to self
- allowing batches including rejection transaction
