### PR TITLE
Use JSON for logging

### DIFF
--- a/src/middleware/not-found-logger.middleware.ts
+++ b/src/middleware/not-found-logger.middleware.ts
@@ -4,6 +4,7 @@ import {
   ILoggingService,
   LoggingService,
 } from '../routes/common/logging/logging.interface';
+import { formatRouteLogMessage } from '../routes/common/logging/utils';
 
 /**
  * Middleware which logs requests that resulted in 404. Request side effects
@@ -20,14 +21,13 @@ export class NotFoundLoggerMiddleware implements NestMiddleware {
   ) {}
 
   use(req: Request, res: Response, next: NextFunction) {
+    const startTimeMs: number = performance.now();
+
     res.on('finish', () => {
       const { statusCode } = res;
       if (statusCode === 404) {
         this.loggingService.info(
-          '[==>] %s %s %d',
-          req.method,
-          req.url,
-          res.statusCode,
+          formatRouteLogMessage(statusCode, req, startTimeMs),
         );
       }
     });

--- a/src/routes/common/interceptors/route-logger.interceptor.spec.ts
+++ b/src/routes/common/interceptors/route-logger.interceptor.spec.ts
@@ -64,10 +64,14 @@ describe('RouteLoggerInterceptor tests', () => {
 
     expect(mockLoggingService.error).toBeCalledTimes(1);
     expect(mockLoggingService.error).toBeCalledWith(
-      '[==>] %s %s %d',
-      'GET',
-      '/test/server-error',
-      500,
+      expect.objectContaining({
+        client_ip: null,
+        detail: 'Some 500 error',
+        method: 'GET',
+        path: '/test/server-error',
+        route: '/test/server-error',
+        status_code: 500,
+      }),
     );
     expect(mockLoggingService.info).not.toBeCalled();
     expect(mockLoggingService.debug).not.toBeCalled();
@@ -79,10 +83,14 @@ describe('RouteLoggerInterceptor tests', () => {
 
     expect(mockLoggingService.info).toBeCalledTimes(1);
     expect(mockLoggingService.info).toBeCalledWith(
-      '[==>] %s %s %d',
-      'GET',
-      '/test/client-error',
-      405,
+      expect.objectContaining({
+        client_ip: null,
+        detail: 'Some 400 error',
+        method: 'GET',
+        path: '/test/client-error',
+        route: '/test/client-error',
+        status_code: 405,
+      }),
     );
     expect(mockLoggingService.error).not.toBeCalled();
     expect(mockLoggingService.debug).not.toBeCalled();
@@ -94,10 +102,14 @@ describe('RouteLoggerInterceptor tests', () => {
 
     expect(mockLoggingService.info).toBeCalledTimes(1);
     expect(mockLoggingService.info).toBeCalledWith(
-      '[==>] %s %s %d',
-      'GET',
-      '/test/success',
-      200,
+      expect.objectContaining({
+        client_ip: null,
+        detail: null,
+        method: 'GET',
+        path: '/test/success',
+        route: '/test/success',
+        status_code: 200,
+      }),
     );
     expect(mockLoggingService.error).not.toBeCalled();
     expect(mockLoggingService.debug).not.toBeCalled();
@@ -111,10 +123,14 @@ describe('RouteLoggerInterceptor tests', () => {
 
     expect(mockLoggingService.error).toBeCalledTimes(1);
     expect(mockLoggingService.error).toBeCalledWith(
-      '[==>] %s %s %d',
-      'GET',
-      '/test/server-error-non-http',
-      500,
+      expect.objectContaining({
+        client_ip: null,
+        detail: 'Some random error',
+        method: 'GET',
+        path: '/test/server-error-non-http',
+        route: '/test/server-error-non-http',
+        status_code: 500,
+      }),
     );
     expect(mockLoggingService.info).not.toBeCalled();
     expect(mockLoggingService.debug).not.toBeCalled();

--- a/src/routes/common/interceptors/route-logger.interceptor.spec.ts
+++ b/src/routes/common/interceptors/route-logger.interceptor.spec.ts
@@ -63,16 +63,15 @@ describe('RouteLoggerInterceptor tests', () => {
     await request(app.getHttpServer()).get('/test/server-error').expect(500);
 
     expect(mockLoggingService.error).toBeCalledTimes(1);
-    expect(mockLoggingService.error).toBeCalledWith(
-      expect.objectContaining({
-        client_ip: null,
-        detail: 'Some 500 error',
-        method: 'GET',
-        path: '/test/server-error',
-        route: '/test/server-error',
-        status_code: 500,
-      }),
-    );
+    expect(mockLoggingService.error).toBeCalledWith({
+      client_ip: null,
+      detail: 'Some 500 error',
+      method: 'GET',
+      path: '/test/server-error',
+      response_time_ms: expect.any(Number),
+      route: '/test/server-error',
+      status_code: 500,
+    });
     expect(mockLoggingService.info).not.toBeCalled();
     expect(mockLoggingService.debug).not.toBeCalled();
     expect(mockLoggingService.warn).not.toBeCalled();
@@ -82,16 +81,15 @@ describe('RouteLoggerInterceptor tests', () => {
     await request(app.getHttpServer()).get('/test/client-error').expect(405);
 
     expect(mockLoggingService.info).toBeCalledTimes(1);
-    expect(mockLoggingService.info).toBeCalledWith(
-      expect.objectContaining({
-        client_ip: null,
-        detail: 'Some 400 error',
-        method: 'GET',
-        path: '/test/client-error',
-        route: '/test/client-error',
-        status_code: 405,
-      }),
-    );
+    expect(mockLoggingService.info).toBeCalledWith({
+      client_ip: null,
+      detail: 'Some 400 error',
+      method: 'GET',
+      path: '/test/client-error',
+      response_time_ms: expect.any(Number),
+      route: '/test/client-error',
+      status_code: 405,
+    });
     expect(mockLoggingService.error).not.toBeCalled();
     expect(mockLoggingService.debug).not.toBeCalled();
     expect(mockLoggingService.warn).not.toBeCalled();
@@ -101,16 +99,15 @@ describe('RouteLoggerInterceptor tests', () => {
     await request(app.getHttpServer()).get('/test/success').expect(200);
 
     expect(mockLoggingService.info).toBeCalledTimes(1);
-    expect(mockLoggingService.info).toBeCalledWith(
-      expect.objectContaining({
-        client_ip: null,
-        detail: null,
-        method: 'GET',
-        path: '/test/success',
-        route: '/test/success',
-        status_code: 200,
-      }),
-    );
+    expect(mockLoggingService.info).toBeCalledWith({
+      client_ip: null,
+      detail: null,
+      method: 'GET',
+      path: '/test/success',
+      response_time_ms: expect.any(Number),
+      route: '/test/success',
+      status_code: 200,
+    });
     expect(mockLoggingService.error).not.toBeCalled();
     expect(mockLoggingService.debug).not.toBeCalled();
     expect(mockLoggingService.warn).not.toBeCalled();
@@ -122,16 +119,15 @@ describe('RouteLoggerInterceptor tests', () => {
       .expect(500);
 
     expect(mockLoggingService.error).toBeCalledTimes(1);
-    expect(mockLoggingService.error).toBeCalledWith(
-      expect.objectContaining({
-        client_ip: null,
-        detail: 'Some random error',
-        method: 'GET',
-        path: '/test/server-error-non-http',
-        route: '/test/server-error-non-http',
-        status_code: 500,
-      }),
-    );
+    expect(mockLoggingService.error).toBeCalledWith({
+      client_ip: null,
+      detail: 'Some random error',
+      method: 'GET',
+      path: '/test/server-error-non-http',
+      response_time_ms: expect.any(Number),
+      route: '/test/server-error-non-http',
+      status_code: 500,
+    });
     expect(mockLoggingService.info).not.toBeCalled();
     expect(mockLoggingService.debug).not.toBeCalled();
     expect(mockLoggingService.warn).not.toBeCalled();

--- a/src/routes/common/interceptors/route-logger.interceptor.ts
+++ b/src/routes/common/interceptors/route-logger.interceptor.ts
@@ -9,6 +9,7 @@ import {
 import { ILoggingService, LoggingService } from '../logging/logging.interface';
 import { Inject } from '@nestjs/common/decorators';
 import { Observable, tap } from 'rxjs';
+import { formatRouteLogMessage } from '../logging/utils';
 
 /**
  * The {@link RouteLoggerInterceptor} is an interceptor that logs the requests
@@ -24,21 +25,21 @@ import { Observable, tap } from 'rxjs';
  */
 @Injectable()
 export class RouteLoggerInterceptor implements NestInterceptor {
-  private static LOG_FORMAT = '[==>] %s %s %d';
-
   constructor(
     @Inject(LoggingService) private readonly loggingService: ILoggingService,
   ) {}
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const startTimeMs: number = performance.now();
+
     const httpContext = context.switchToHttp();
     const request = httpContext.getRequest();
     const response = httpContext.getResponse();
-    // TODO Use req.route.path to log the route path without any replacement
+
     return next.handle().pipe(
       tap({
-        error: (e) => this.onError(request, e),
-        complete: () => this.onComplete(request, response),
+        error: (e) => this.onError(request, e, startTimeMs),
+        complete: () => this.onComplete(request, response, startTimeMs),
       }),
     );
   }
@@ -54,37 +55,33 @@ export class RouteLoggerInterceptor implements NestInterceptor {
    * See https://github.com/nestjs/nest/issues/1342#issuecomment-444666214
    * @param request - the request object used in this context
    * @param error - the error which was triggered in the stream
+   * @param startTimeMs - the starting timestamp in milliseconds used to
+   * compute the response time of the route
    * @private
    */
-  private onError(request: any, error: Error) {
+  private onError(request: any, error: Error, startTimeMs: number) {
     const statusCode =
       error instanceof HttpException
         ? error.getStatus()
         : HttpStatus.INTERNAL_SERVER_ERROR;
 
+    const message = formatRouteLogMessage(
+      statusCode,
+      request,
+      startTimeMs,
+      error.message,
+    );
+
     if (statusCode >= 400 && statusCode < 500) {
-      this.loggingService.info(
-        RouteLoggerInterceptor.LOG_FORMAT,
-        request.method,
-        request.url,
-        statusCode,
-      );
+      this.loggingService.info(message);
     } else {
-      this.loggingService.error(
-        RouteLoggerInterceptor.LOG_FORMAT,
-        request.method,
-        request.url,
-        statusCode,
-      );
+      this.loggingService.error(message);
     }
   }
 
-  private onComplete(request: any, response: any) {
+  private onComplete(request: any, response: any, startTimeMs: number) {
     this.loggingService.info(
-      RouteLoggerInterceptor.LOG_FORMAT,
-      request.method,
-      request.url,
-      response.statusCode,
+      formatRouteLogMessage(response.statusCode, request, startTimeMs),
     );
   }
 }

--- a/src/routes/common/logging/logging.interface.ts
+++ b/src/routes/common/logging/logging.interface.ts
@@ -1,8 +1,11 @@
 export const LoggingService = Symbol('ILoggingService');
 
 export interface ILoggingService {
-  info(message: string, ...optionalParams: unknown[]): void;
-  debug(message: string, ...optionalParams: unknown[]): void;
-  error(message: string, ...optionalParams: unknown[]): void;
-  warn(message: string, ...optionalParams: unknown[]): void;
+  info(message: string | unknown): void;
+
+  debug(message: string | unknown): void;
+
+  error(message: string | unknown): void;
+
+  warn(message: string | unknown): void;
 }

--- a/src/routes/common/logging/logging.module.ts
+++ b/src/routes/common/logging/logging.module.ts
@@ -22,10 +22,7 @@ const LoggerTransports = Symbol('LoggerTransports');
 function winstonTransportsFactory(): Transport[] | Transport {
   return new winston.transports.Console({
     level: 'debug',
-    format: winston.format.combine(
-      winston.format.splat(),
-      winston.format.simple(),
-    ),
+    format: winston.format.json(),
   });
 }
 

--- a/src/routes/common/logging/logging.service.spec.ts
+++ b/src/routes/common/logging/logging.service.spec.ts
@@ -7,10 +7,7 @@ const mockClsService = {
 } as unknown as ClsService;
 
 const mockLogger = {
-  info: jest.fn(),
-  error: jest.fn(),
-  warn: jest.fn(),
-  debug: jest.fn(),
+  log: jest.fn(),
 } as unknown as winston.Logger;
 
 describe('RequestScopedLoggingService', () => {
@@ -34,10 +31,12 @@ describe('RequestScopedLoggingService', () => {
 
     loggingService.info(message);
 
-    expect(mockLogger.info).toHaveBeenCalledTimes(1);
-    expect(mockLogger.info).toHaveBeenCalledWith(
-      `${new Date('2023-01-01').toISOString()} 123-456 - ${message}`,
-    );
+    expect(mockLogger.log).toHaveBeenCalledTimes(1);
+    expect(mockLogger.log).toHaveBeenCalledWith('info', {
+      message: 'Some message',
+      request_id: '123-456',
+      timestamp: new Date('2023-01-01').toISOString(),
+    });
   });
 
   it('error', () => {
@@ -45,10 +44,12 @@ describe('RequestScopedLoggingService', () => {
 
     loggingService.error(message);
 
-    expect(mockLogger.error).toHaveBeenCalledTimes(1);
-    expect(mockLogger.error).toHaveBeenCalledWith(
-      `${new Date('2023-01-01').toISOString()} 123-456 - ${message}`,
-    );
+    expect(mockLogger.log).toHaveBeenCalledTimes(1);
+    expect(mockLogger.log).toHaveBeenCalledWith('error', {
+      message: 'Some message',
+      request_id: '123-456',
+      timestamp: new Date('2023-01-01').toISOString(),
+    });
   });
 
   it('warn', () => {
@@ -56,10 +57,12 @@ describe('RequestScopedLoggingService', () => {
 
     loggingService.warn(message);
 
-    expect(mockLogger.warn).toHaveBeenCalledTimes(1);
-    expect(mockLogger.warn).toHaveBeenCalledWith(
-      `${new Date('2023-01-01').toISOString()} 123-456 - ${message}`,
-    );
+    expect(mockLogger.log).toHaveBeenCalledTimes(1);
+    expect(mockLogger.log).toHaveBeenCalledWith('warn', {
+      message: 'Some message',
+      request_id: '123-456',
+      timestamp: new Date('2023-01-01').toISOString(),
+    });
   });
 
   it('debug', () => {
@@ -67,9 +70,11 @@ describe('RequestScopedLoggingService', () => {
 
     loggingService.debug(message);
 
-    expect(mockLogger.debug).toHaveBeenCalledTimes(1);
-    expect(mockLogger.debug).toHaveBeenCalledWith(
-      `${new Date('2023-01-01').toISOString()} 123-456 - ${message}`,
-    );
+    expect(mockLogger.log).toHaveBeenCalledTimes(1);
+    expect(mockLogger.log).toHaveBeenCalledWith('debug', {
+      message: 'Some message',
+      request_id: '123-456',
+      timestamp: new Date('2023-01-01').toISOString(),
+    });
   });
 });

--- a/src/routes/common/logging/logging.service.spec.ts
+++ b/src/routes/common/logging/logging.service.spec.ts
@@ -1,6 +1,7 @@
 import { ClsService } from 'nestjs-cls';
 import { RequestScopedLoggingService } from './logging.service';
 import * as winston from 'winston';
+import { faker } from '@faker-js/faker';
 
 const mockClsService = {
   getId: jest.fn(() => '123-456'),
@@ -11,11 +12,13 @@ const mockLogger = {
 } as unknown as winston.Logger;
 
 describe('RequestScopedLoggingService', () => {
+  const systemTime: Date = faker.date.recent();
+
   let loggingService: RequestScopedLoggingService;
 
   beforeAll(() => {
     jest.useFakeTimers();
-    jest.setSystemTime(new Date('2023-01-01'));
+    jest.setSystemTime(systemTime);
   });
 
   beforeEach(() => {
@@ -35,7 +38,7 @@ describe('RequestScopedLoggingService', () => {
     expect(mockLogger.log).toHaveBeenCalledWith('info', {
       message: 'Some message',
       request_id: '123-456',
-      timestamp: new Date('2023-01-01').toISOString(),
+      timestamp: systemTime.toISOString(),
     });
   });
 
@@ -48,7 +51,7 @@ describe('RequestScopedLoggingService', () => {
     expect(mockLogger.log).toHaveBeenCalledWith('error', {
       message: 'Some message',
       request_id: '123-456',
-      timestamp: new Date('2023-01-01').toISOString(),
+      timestamp: systemTime.toISOString(),
     });
   });
 
@@ -61,7 +64,7 @@ describe('RequestScopedLoggingService', () => {
     expect(mockLogger.log).toHaveBeenCalledWith('warn', {
       message: 'Some message',
       request_id: '123-456',
-      timestamp: new Date('2023-01-01').toISOString(),
+      timestamp: systemTime.toISOString(),
     });
   });
 
@@ -74,7 +77,7 @@ describe('RequestScopedLoggingService', () => {
     expect(mockLogger.log).toHaveBeenCalledWith('debug', {
       message: 'Some message',
       request_id: '123-456',
-      timestamp: new Date('2023-01-01').toISOString(),
+      timestamp: systemTime.toISOString(),
     });
   });
 });

--- a/src/routes/common/logging/logging.service.ts
+++ b/src/routes/common/logging/logging.service.ts
@@ -16,26 +16,31 @@ export class RequestScopedLoggingService implements ILoggingService {
     private readonly cls: ClsService,
   ) {}
 
-  info(message: string, ...optionalParams: unknown[]) {
-    this.logger.info(this.transformMessage(message), ...optionalParams);
+  info(message: string | unknown) {
+    this.logger.log('info', this.formatMessage(message));
   }
 
-  error(message: string, ...optionalParams: unknown[]) {
-    this.logger.error(this.transformMessage(message), ...optionalParams);
+  error(message: string | unknown) {
+    this.logger.log('error', this.formatMessage(message));
   }
 
-  warn(message: string, ...optionalParams: unknown[]) {
-    this.logger.warn(this.transformMessage(message), ...optionalParams);
+  warn(message: string | unknown) {
+    this.logger.log('warn', this.formatMessage(message));
   }
 
-  debug(message: string, ...optionalParams: unknown[]) {
-    this.logger.debug(this.transformMessage(message), ...optionalParams);
+  debug(message: string | unknown) {
+    this.logger.log('debug', this.formatMessage(message));
   }
 
-  private transformMessage(message: string): string {
+  private formatMessage(message: string | unknown): unknown {
     const requestId = this.cls.getId();
     const timestamp = Date.now();
     const dateAsString = new Date(timestamp).toISOString();
-    return `${dateAsString} ${requestId} - ${message}`;
+
+    return {
+      message,
+      request_id: requestId,
+      timestamp: dateAsString,
+    };
   }
 }

--- a/src/routes/common/logging/logging.service.ts
+++ b/src/routes/common/logging/logging.service.ts
@@ -32,7 +32,7 @@ export class RequestScopedLoggingService implements ILoggingService {
     this.logger.log('debug', this.formatMessage(message));
   }
 
-  private formatMessage(message: string | unknown): unknown {
+  private formatMessage(message: string | unknown) {
     const requestId = this.cls.getId();
     const timestamp = Date.now();
     const dateAsString = new Date(timestamp).toISOString();

--- a/src/routes/common/logging/utils.ts
+++ b/src/routes/common/logging/utils.ts
@@ -1,0 +1,20 @@
+const HEADER_IP_ADDRESS = 'X-Real-IP';
+
+export function formatRouteLogMessage(
+  statusCode: number,
+  request: any,
+  startTimeMs: number,
+  detail?: string,
+): unknown {
+  const clientIp = request.header(HEADER_IP_ADDRESS) ?? null;
+
+  return {
+    client_ip: clientIp,
+    method: request.method,
+    response_time_ms: performance.now() - startTimeMs,
+    route: request.route.path,
+    path: request.url,
+    status_code: statusCode,
+    detail: detail ?? null,
+  };
+}

--- a/src/routes/common/logging/utils.ts
+++ b/src/routes/common/logging/utils.ts
@@ -5,7 +5,7 @@ export function formatRouteLogMessage(
   request: any,
   startTimeMs: number,
   detail?: string,
-): unknown {
+) {
   const clientIp = request.header(HEADER_IP_ADDRESS) ?? null;
 
   return {

--- a/src/routes/relay/relay.service.ts
+++ b/src/routes/relay/relay.service.ts
@@ -47,8 +47,7 @@ export class RelayService {
       response = await this.sponsorService.sponsoredCall(sponsoredCallDto);
     } catch (err) {
       this.loggingService.error(
-        'Unexpected error from Gelato sponsored call: `%s`',
-        err,
+        `Unexpected error from Gelato sponsored call: ${err}`,
       );
       throw new HttpException('Relay failed', HttpStatus.INTERNAL_SERVER_ERROR);
     }


### PR DESCRIPTION
- Uses JSON as the default logging format – `winston.format.json()` is now the main formatter
- The `ILoggingService` interface changed to accommodate the new format – a `message` can now be an unknown payload format or a `string` – regardless of the type, this value will be logged under `{ message: <value> }`

The base format of the logs are as follows:

```javascript
{
  message: <string | object>, // string value or json payload
  request_id: <string>, // id tied to the request
  timestamp: <string>, // ISO 8601 Date string
}
```

The `message` value when logging route requests is as follows:

```javascript
{
  ...
  message: {
      client_ip: <optional string>, // retrieved from the header X-Real-IP. null if not available
      method: <string>, // GET, POST, etc..
      response_time_ms: <number>, // response time in milliseconds
      route: <optional string>, // route which handled the request. Null if no route handled this request (eg.: 404 requests)
      path: <string>, // path of the resource requested
      status_code: <number>, // resulting status code of the request
      detail: <optional string>, // optional message regarding the result of the request
  }
}
```