### PR TITLE
fix: relay Safe-related transactions

### DIFF
--- a/src/__mocks__/transaction-calldata.mock.ts
+++ b/src/__mocks__/transaction-calldata.mock.ts
@@ -39,7 +39,7 @@ function encodeSafeFunctionData(
   return safeInterface.encodeFunctionData(...args);
 }
 
-export async function getMockExecTransactionCalldata({
+export function getMockExecTransactionCalldata({
   to,
   value,
   data = '0x',
@@ -61,7 +61,7 @@ export async function getMockExecTransactionCalldata({
   gasToken?: string;
   refundReceiver?: string;
   signatures?: string;
-}): Promise<string> {
+}): string {
   return encodeSafeFunctionData('execTransaction', [
     to,
     value,
@@ -138,13 +138,13 @@ function getMultiSendCallOnlyInterface(
   return new ethers.Interface(multiSendDeployment.abi);
 }
 
-export async function getMockMultiSendCalldata(
+export function getMockMultiSendCalldata(
   transactions: Array<{
     to: string;
     value: number;
     data: string;
   }>,
-): Promise<string> {
+): string {
   // MultiSendCallOnly
   const OPERATION = 0;
 
@@ -162,7 +162,7 @@ export async function getMockMultiSendCalldata(
   ]);
 }
 
-async function getMockSetupCalldata({
+function getMockSetupCalldata({
   owners,
   threshold,
   to = faker.finance.ethereumAddress(),
@@ -180,10 +180,8 @@ async function getMockSetupCalldata({
   paymentToken?: string;
   payment?: number;
   paymentReceiver?: string;
-}): Promise<string> {
-  const safeInterface = getSafeSingletonInterface();
-
-  return safeInterface.encodeFunctionData('setup', [
+}): string {
+  return encodeSafeFunctionData('setup', [
     owners,
     threshold,
     to,
@@ -205,7 +203,7 @@ function getProxyFactoryInterface(filter?: DeploymentFilter): ethers.Interface {
   return new ethers.Interface(deployment.abi);
 }
 
-export async function getMockCreateProxyWithNonceCalldata({
+export function getMockCreateProxyWithNonceCalldata({
   owners,
   threshold,
   singleton,
@@ -215,10 +213,10 @@ export async function getMockCreateProxyWithNonceCalldata({
   threshold: number;
   singleton: string;
   saltNonce?: number;
-}): Promise<string> {
+}): string {
   const proxyFactoryInterface = getProxyFactoryInterface();
 
-  const initializer = await getMockSetupCalldata({ owners, threshold });
+  const initializer = getMockSetupCalldata({ owners, threshold });
 
   return proxyFactoryInterface.encodeFunctionData('createProxyWithNonce', [
     singleton,

--- a/src/__mocks__/transaction-calldata.mock.ts
+++ b/src/__mocks__/transaction-calldata.mock.ts
@@ -30,6 +30,15 @@ function getPrevalidatedSignature(address: string): string {
   )}000000000000000000000000000000000000000000000000000000000000000001`;
 }
 
+function encodeSafeFunctionData(
+  ...args: Parameters<
+    InstanceType<typeof ethers.Interface>['encodeFunctionData']
+  >
+): string {
+  const safeInterface = getSafeSingletonInterface();
+  return safeInterface.encodeFunctionData(...args);
+}
+
 export async function getMockExecTransactionCalldata({
   to,
   value,
@@ -53,9 +62,7 @@ export async function getMockExecTransactionCalldata({
   refundReceiver?: string;
   signatures?: string;
 }): Promise<string> {
-  const safeInterface = getSafeSingletonInterface();
-
-  return safeInterface.encodeFunctionData('execTransaction', [
+  return encodeSafeFunctionData('execTransaction', [
     to,
     value,
     data,
@@ -66,6 +73,56 @@ export async function getMockExecTransactionCalldata({
     gasToken,
     refundReceiver,
     signatures,
+  ]);
+}
+
+export function getMockAddOwnerWithThresholdCalldata() {
+  return encodeSafeFunctionData('addOwnerWithThreshold', [
+    faker.finance.ethereumAddress(),
+    faker.datatype.number(),
+  ]);
+}
+
+export function getMockChangeThresholdCalldata() {
+  return encodeSafeFunctionData('changeThreshold', [faker.datatype.number()]);
+}
+
+export function getMockDisableModuleCalldata() {
+  return encodeSafeFunctionData('disableModule', [
+    faker.finance.ethereumAddress(),
+    faker.finance.ethereumAddress(),
+  ]);
+}
+
+export function getMockEnableModuleCalldata() {
+  return encodeSafeFunctionData('enableModule', [
+    faker.finance.ethereumAddress(),
+  ]);
+}
+
+export function getMockRemoveOwnerCallData() {
+  return encodeSafeFunctionData('removeOwner', [
+    faker.finance.ethereumAddress(),
+    faker.finance.ethereumAddress(),
+    1,
+  ]);
+}
+
+export function getMockSetFallbackHandlerCalldata() {
+  return encodeSafeFunctionData('setFallbackHandler', [
+    faker.finance.ethereumAddress(),
+  ]);
+}
+
+export function getMockSetGuardCalldata() {
+  return encodeSafeFunctionData('setGuard', [faker.finance.ethereumAddress()]);
+}
+
+export function getMockSwapOwnerCallData() {
+  return encodeSafeFunctionData('swapOwner', [
+    faker.finance.ethereumAddress(),
+    faker.finance.ethereumAddress(),
+    faker.finance.ethereumAddress(),
   ]);
 }
 

--- a/src/routes/relay/entities/schema/sponsored-call.schema.helper.ts
+++ b/src/routes/relay/entities/schema/sponsored-call.schema.helper.ts
@@ -99,7 +99,7 @@ export const isValidExecTransactionCall = (
     data,
   );
 
-  // Transaction to another another party
+  // Transaction to another party
   const toSelf = to === txTo;
   if (!toSelf) {
     return true;

--- a/src/routes/relay/entities/schema/sponsored-call.schema.helper.ts
+++ b/src/routes/relay/entities/schema/sponsored-call.schema.helper.ts
@@ -1,10 +1,11 @@
+import { ethers } from 'ethers';
 import {
   getMultiSendCallOnlyDeployment,
   getProxyFactoryDeployment,
   getSafeL2SingletonDeployment,
   getSafeSingletonDeployment,
 } from '@safe-global/safe-deployments';
-import { ethers } from 'ethers';
+import type { SingletonDeployment } from '@safe-global/safe-deployments';
 
 // ======================== General ========================
 
@@ -17,6 +18,45 @@ const isCalldata = (data: string, signature: string): boolean => {
   const signatureId = ethers.id(signature).slice(0, 10);
 
   return data.startsWith(signatureId);
+};
+
+/**
+ * Checks whether data is a call to any method in the specified singleton
+ * @param singletonDeployment singleton deployment
+ * @param data call data
+ * @returns boolean
+ */
+const isSingletonCalldata = (
+  singletonDeployment: SingletonDeployment,
+  data: string,
+): boolean => {
+  const deploymentInterface = new ethers.Interface(singletonDeployment.abi);
+
+  return deploymentInterface.fragments.some((fragment) => {
+    if (ethers.FunctionFragment.isFunction(fragment)) {
+      const signature = fragment.format();
+      return isCalldata(data, signature);
+    }
+  });
+};
+
+/**
+ * Checks whether data is a call to any method in the Safe singleton
+ * @param data call data
+ * @returns boolean
+ */
+export const isSafeCalldata = (data: string): boolean => {
+  const safeL1Deployment = getSafeSingletonDeployment();
+  const safeL2Deployment = getSafeL2SingletonDeployment();
+
+  if (!safeL1Deployment || !safeL2Deployment) {
+    return false;
+  }
+
+  return (
+    isSingletonCalldata(safeL1Deployment, data) ||
+    isSingletonCalldata(safeL2Deployment, data)
+  );
 };
 
 // ==================== execTransaction ====================
@@ -34,7 +74,8 @@ const isExecTransactionCalldata = (data: string): boolean => {
 };
 
 /**
- * Validates that the call `data` is `execTransaction` and the `to` address is not self, other than rejections
+ * Validates that the call `data` is `execTransaction` and the `to` address is not self
+ * other than Safe-specific ones such as owner management or setting the fallback handler
  *
  * @param to recipient address
  * @param data execTransaction call data
@@ -58,10 +99,21 @@ export const isValidExecTransactionCall = (
     data,
   );
 
+  // Transaction to another another party
   const toSelf = to === txTo;
-  const isRejectionTx = toSelf && Number(txValue) === 0 && txData === '0x';
+  if (!toSelf) {
+    return true;
+  }
 
-  return !toSelf || isRejectionTx;
+  // `execTransaction` to self
+  const hasValue = Number(txValue) > 0;
+  if (hasValue) {
+    return false;
+  }
+
+  // Safe-specific transaction, e.g. `setFallbackHandler`
+  const isCancellation = txData === '0x';
+  return isCancellation || isSafeCalldata(txData);
 };
 
 // ======================= multiSend =======================


### PR DESCRIPTION
This resolves #75 by allowing Safe-related transactions to self such as owner management, threshold changes and setting the Fallback Handler.

The calldata is checked against the official deployment ABIs for validity when the `execTransaction` is to self with no value.