### PR TITLE
fix: don't relay ERC-20 `transfer` calls to self

### DIFF
--- a/src/__mocks__/transaction-calldata.mock.ts
+++ b/src/__mocks__/transaction-calldata.mock.ts
@@ -224,3 +224,18 @@ export function getMockCreateProxyWithNonceCalldata({
     saltNonce,
   ]);
 }
+
+export function getMockErc20TransferCalldata({
+  to,
+  value,
+}: {
+  to: string;
+  value: number;
+}): string {
+  const ERC20_TRANFER_FRAGMENT = 'function transfer(address,uint256)';
+
+  return new ethers.Interface([ERC20_TRANFER_FRAGMENT]).encodeFunctionData(
+    'transfer',
+    [to, value],
+  );
+}

--- a/src/routes/relay/relay.controller.spec.ts
+++ b/src/routes/relay/relay.controller.spec.ts
@@ -162,20 +162,17 @@ describe('RelayController', () => {
         });
 
         it('should return a 201 when the body is an ERC-20 tranfer execTransaction call', async () => {
-          const token = faker.finance.ethereumAddress();
-          const safe = faker.finance.ethereumAddress();
-
           const data = getMockExecTransactionCalldata({
-            to: token,
+            to: faker.finance.ethereumAddress(),
             // ERC-20 transfer transactions have a value of 0
             value: 0,
             data: getMockErc20TransferCalldata({
-              to: safe,
+              to: faker.finance.ethereumAddress(),
               value: 1,
             }),
           });
 
-          await testSuccessfulSafeTx(safe, data);
+          await testSuccessfulSafeTx(faker.finance.ethereumAddress(), data);
         });
 
         it('should return a 201 when the body is a cancellation execTransaction call', async () => {

--- a/src/routes/relay/relay.controller.spec.ts
+++ b/src/routes/relay/relay.controller.spec.ts
@@ -162,19 +162,20 @@ describe('RelayController', () => {
         });
 
         it('should return a 201 when the body is an ERC-20 tranfer execTransaction call', async () => {
+          const token = faker.finance.ethereumAddress();
           const safe = faker.finance.ethereumAddress();
 
           const data = getMockExecTransactionCalldata({
-            to: safe,
+            to: token,
             // ERC-20 transfer transactions have a value of 0
             value: 0,
             data: getMockErc20TransferCalldata({
-              to: faker.finance.ethereumAddress(),
+              to: safe,
               value: 1,
             }),
           });
 
-          await testSuccessfulSafeTx(faker.finance.ethereumAddress(), data);
+          await testSuccessfulSafeTx(safe, data);
         });
 
         it('should return a 201 when the body is a cancellation execTransaction call', async () => {
@@ -779,20 +780,20 @@ describe('RelayController', () => {
           true,
         );
 
-        const to = faker.finance.ethereumAddress();
+        const safe = faker.finance.ethereumAddress();
         const data = getMockExecTransactionCalldata({
-          to,
+          to: faker.finance.ethereumAddress(),
           // ERC-20 transfer transactions have a value of 0
           value: 0,
           data: getMockErc20TransferCalldata({
-            to,
+            to: safe,
             value: 1,
           }),
         });
 
         const body = {
           chainId: '5',
-          to,
+          to: safe,
           data,
         };
 


### PR DESCRIPTION
This prevents the relaying of ERC-20 `transfer` calls to self as both singular transactions or in batches. If the decoded `data` of an `execTransaction` calls is that of an ERC-20 `transfer`, it is only valid if the `to` is not that of the Safe requesting relay.