### PR TITLE
Use exception filter for validation error

### DIFF
--- a/src/routes/relay/filters/sponsored-call-validation.exception-filter.ts
+++ b/src/routes/relay/filters/sponsored-call-validation.exception-filter.ts
@@ -1,0 +1,23 @@
+import { SponsoredCallValidationError } from '../pipes/sponsored-call-dto.validator.pipe';
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpStatus,
+} from '@nestjs/common';
+import { Response } from 'express';
+
+@Catch(SponsoredCallValidationError)
+export class SponsoredCallValidationExceptionFilter
+  implements ExceptionFilter<SponsoredCallValidationError>
+{
+  catch(exception: SponsoredCallValidationError, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+
+    response.status(HttpStatus.UNPROCESSABLE_ENTITY).json({
+      statusCode: HttpStatus.UNPROCESSABLE_ENTITY,
+      message: exception.message,
+    });
+  }
+}

--- a/src/routes/relay/pipes/sponsored-call-dto.validator.pipe.ts
+++ b/src/routes/relay/pipes/sponsored-call-dto.validator.pipe.ts
@@ -1,10 +1,4 @@
-import {
-  PipeTransform,
-  Injectable,
-  HttpException,
-  HttpStatus,
-  Inject,
-} from '@nestjs/common';
+import { Inject, Injectable, PipeTransform } from '@nestjs/common';
 
 import {
   ISafeInfoService,
@@ -13,6 +7,12 @@ import {
 import { SponsoredCallSchema } from '../entities/schema/sponsored-call.schema';
 import { isCreateProxyWithNonceCalldata } from '../entities/schema/sponsored-call.schema.helper';
 import { SponsoredCallDto } from '../entities/sponsored-call.entity';
+
+export class SponsoredCallValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}
 
 @Injectable()
 export class SponsoredCallDtoValidatorPipe implements PipeTransform {
@@ -26,10 +26,7 @@ export class SponsoredCallDtoValidatorPipe implements PipeTransform {
     const result = await this.schema.safeParseAsync(value);
 
     if (!result.success) {
-      throw new HttpException(
-        'Validation failed',
-        HttpStatus.UNPROCESSABLE_ENTITY,
-      );
+      throw new SponsoredCallValidationError('Validation failed');
     }
 
     if (!isCreateProxyWithNonceCalldata(result.data.data)) {
@@ -40,9 +37,8 @@ export class SponsoredCallDtoValidatorPipe implements PipeTransform {
       );
 
       if (!isSafeContract) {
-        throw new HttpException(
+        throw new SponsoredCallValidationError(
           'Safe address is not a valid Safe contract',
-          HttpStatus.UNPROCESSABLE_ENTITY,
         );
       }
     }

--- a/src/routes/relay/relay.controller.ts
+++ b/src/routes/relay/relay.controller.ts
@@ -1,5 +1,5 @@
 import { RelayResponse } from '@gelatonetwork/relay-sdk';
-import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, UseFilters } from '@nestjs/common';
 
 import { ZodValidationPipe } from '../../pipes/zod/zod-validation.pipe';
 import { AddressSchema } from '../common/schema/address.schema';
@@ -8,6 +8,7 @@ import { SponsoredCallDto } from './entities/sponsored-call.entity';
 import { RelayService } from './relay.service';
 import { ChainIdSchema } from '../common/schema/chain-id.schema';
 import { RelayLimitService } from './services/relay-limit.service';
+import { SponsoredCallValidationExceptionFilter } from './filters/sponsored-call-validation.exception-filter';
 
 @Controller({
   version: '1',
@@ -20,6 +21,7 @@ export class RelayController {
   ) {}
 
   @Post()
+  @UseFilters(SponsoredCallValidationExceptionFilter)
   sponsoredCall(
     @Body(SponsoredCallDtoValidatorPipe)
     sponsoredCallDto: SponsoredCallDto,


### PR DESCRIPTION
- Adds a `SponsoredCallValidationExceptionFilter` – an `ExceptionFilter` which maps `SponsoredCallValidationError` to the following payload:

```javascript
{
  statusCode: 422,
  message: <string> // error message
}
```

- The main reason for adding `SponsoredCallValidationError` is to separate the validation step from the resulting HTTP payload. The validation pipe should deal with validation only and delegate HTTP mapping to the routes or other components (in this case, an exception filter).
- This exception filter is only applied to `POST /v1/relay/`. Throwing a `SponsoredCallValidationError` in other routes will result in a `500` error