### PR TITLE
fix: move contract types to `/src`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 /node_modules
 
 # Contract types
-/contracts
+/src/contracts
 
 # Logs
 logs

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+
+# Contract types
+/src/contracts

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "typechain": "typechain --target=ethers-v6",
-    "types:openzeppelin": "yarn typechain --out-dir contracts/openzeppelin ./node_modules/@openzeppelin/contracts/build/contracts/ERC20.json",
-    "types:safe": "yarn typechain --out-dir contracts/safe ./node_modules/@safe-global/safe-deployments/dist/assets/**/*.json",
+    "types:openzeppelin": "yarn typechain --out-dir src/contracts/openzeppelin ./node_modules/@openzeppelin/contracts/build/contracts/ERC20.json",
+    "types:safe": "yarn typechain --out-dir src/contracts/safe ./node_modules/@safe-global/safe-deployments/dist/assets/**/*.json",
     "postinstall": "husky install && yarn types:openzeppelin && yarn types:safe"
   },
   "dependencies": {

--- a/src/__mocks__/transaction-calldata.mock.ts
+++ b/src/__mocks__/transaction-calldata.mock.ts
@@ -5,8 +5,8 @@ import {
   Gnosis_safe__factory,
   Multi_send__factory,
   Proxy_factory__factory,
-} from '../../contracts/safe/factories/v1.3.0';
-import { ERC20__factory } from '../../contracts/openzeppelin';
+} from '../contracts/safe/factories/v1.3.0';
+import { ERC20__factory } from '../contracts/openzeppelin';
 
 export const MOCK_UNSUPPORTED_CALLDATA = new ethers.Interface([
   'function unsupported()',

--- a/src/routes/relay/entities/schema/sponsored-call.schema.helper.ts
+++ b/src/routes/relay/entities/schema/sponsored-call.schema.helper.ts
@@ -7,12 +7,12 @@ import {
 } from '@safe-global/safe-deployments';
 import type { SingletonDeployment } from '@safe-global/safe-deployments';
 
-import { ERC20__factory } from '../../../../../contracts/openzeppelin';
+import { ERC20__factory } from '../../../../contracts/openzeppelin';
 import {
   Gnosis_safe__factory,
   Multi_send__factory,
   Proxy_factory__factory,
-} from '../../../../../contracts/safe/factories/v1.3.0';
+} from '../../../../contracts/safe/factories/v1.3.0';
 
 // ======================== General ========================
 


### PR DESCRIPTION
This moves the autogenerated types into the `/src` directory to fix the service build. (Autodeploy was previously failing as the types were outside of the built `dist`.)