### PR TITLE
Mount cache in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,11 @@
 # BUILD CONTAINER
 #
 FROM node:18 as base
-USER node
 ENV NODE_ENV production
 WORKDIR /app
 COPY --chown=node:node .yarn/releases ./.yarn/releases
 COPY --chown=node:node package.json yarn.lock .yarnrc.yml tsconfig*.json ./
-RUN --mount=type=cache,target="${HOME}/.yarn" YARN_CACHE_FOLDER="${HOME}/.yarn" yarn install --immutable
+RUN --mount=type=cache,target=/root/.yarn YARN_CACHE_FOLDER=/root/.yarn yarn install --immutable
 COPY src/ ./
 RUN yarn run build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,12 @@
 # BUILD CONTAINER
 #
 FROM node:18 as base
+USER node
 ENV NODE_ENV production
 WORKDIR /app
-COPY .yarn/releases ./.yarn/releases
-COPY package.json yarn.lock .yarnrc.yml tsconfig*.json ./
-RUN --mount=type=cache,target=/root/.yarn YARN_CACHE_FOLDER=/root/.yarn yarn install --immutable
+COPY --chown=node:node .yarn/releases ./.yarn/releases
+COPY --chown=node:node package.json yarn.lock .yarnrc.yml tsconfig*.json ./
+RUN --mount=type=cache,target="${HOME}/.yarn" YARN_CACHE_FOLDER="${HOME}/.yarn" yarn install --immutable
 COPY src/ ./
 RUN yarn run build
 
@@ -14,6 +15,7 @@ RUN yarn run build
 # PRODUCTION CONTAINER
 #
 FROM node:18-alpine as production
-COPY --from=base /app/node_modules ./node_modules
-COPY --from=base /app/dist ./dist
+USER node
+COPY --chown=node:node --from=base /app/node_modules ./node_modules
+COPY --chown=node:node --from=base /app/dist ./dist
 CMD [ "node", "dist/main.js" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,20 +2,18 @@
 # BUILD CONTAINER
 #
 FROM node:18 as base
-USER node
 ENV NODE_ENV production
 WORKDIR /app
-COPY --chown=node:node package.json yarn.lock .yarnrc.yml tsconfig*.json ./
-COPY --chown=node:node .yarn/releases ./.yarn/releases
-RUN yarn install --immutable 
-COPY --chown=node:node . .
+COPY .yarn/releases ./.yarn/releases
+COPY package.json yarn.lock .yarnrc.yml tsconfig*.json ./
+RUN --mount=type=cache,target=/root/.yarn YARN_CACHE_FOLDER=/root/.yarn yarn install --immutable
+COPY src/ ./
 RUN yarn run build
 
 #
 # PRODUCTION CONTAINER
 #
 FROM node:18-alpine as production
-USER node
-COPY --chown=node:node --from=base /app/node_modules ./node_modules
-COPY --chown=node:node --from=base /app/dist ./dist
+COPY --from=base /app/node_modules ./node_modules
+COPY --from=base /app/dist ./dist
 CMD [ "node", "dist/main.js" ]


### PR DESCRIPTION
- The provided Docker image now uses cache folder to store the yarn dependencies. If a dependency is updated, rebuilding the image is now faster since only the affected dependencies will be fetched.
- Copying `.yarn/releases` now happens before copying the `package.json` and `yarn.lock` – we often see more dependency updates than yarn updates: by having the dependency tree related files before the Yarn releases, we'd invalidate the Yarn releases Docker layer once there's a dependency update
- Copies only the `src` folder to the `base` container instead of the whole project folder. This was done to reduce the overall image size but more importantly to raise awareness of which files we actually need in the final Docker image

~Removes `node` as the user for these actions with the goal of simplifying the overall script and actions being performed~

It'd be good to explore ways to make the Github Actions cache available to the Docker image (the npm packages). There's an interesting issue [here](https://github.com/moby/buildkit/issues/1512) which would allow mounting a volume for the cache used in `--mount=type=cache`. However this can raise other questions such as cache compatibility between different architectures and OS.