### PR TITLE
Fix src folder COPY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 COPY --chown=node:node .yarn/releases ./.yarn/releases
 COPY --chown=node:node package.json yarn.lock .yarnrc.yml tsconfig*.json ./
 RUN --mount=type=cache,target=/root/.yarn YARN_CACHE_FOLDER=/root/.yarn yarn install --immutable
-COPY src/ ./
+COPY src ./src
 RUN yarn run build
 
 #


### PR DESCRIPTION
- The `COPY` command is incorrectly copying the contents to `src` folder to `/app` – this creates some invalid paths used in imports such as the generated TypeChain `contracts/`