### PR TITLE
Isolate @nestjs/testing dependency

### DIFF
--- a/src/__tests__/test-app.provider.ts
+++ b/src/__tests__/test-app.provider.ts
@@ -1,0 +1,28 @@
+import { AppProvider, DEFAULT_CONFIGURATION } from '../app.provider';
+import { INestApplication } from '@nestjs/common';
+import { TestingModule } from '@nestjs/testing';
+
+/**
+ * A test {@link AppProvider}
+ *
+ * This provider provides an application given a {@link TestingModule}
+ *
+ * If the module provided is not a {@link TestingModule}, an error is thrown
+ */
+export class TestAppProvider extends AppProvider {
+  protected readonly configuration: Array<(app: INestApplication) => void> =
+    DEFAULT_CONFIGURATION;
+
+  constructor() {
+    super();
+    if (process.env.NODE_ENV !== 'test') {
+      throw Error('TestAppProvider used outside of a testing environment');
+    }
+  }
+
+  protected getApp(module: unknown): Promise<INestApplication> {
+    if (!(module instanceof TestingModule))
+      return Promise.reject(`Provided module is not a TestingModule`);
+    return Promise.resolve(module.createNestApplication());
+  }
+}

--- a/src/app.module.spec.ts
+++ b/src/app.module.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 
 import { AppModule } from './app.module';
-import { TestAppProvider } from './app.provider';
+import { TestAppProvider } from './__tests__/test-app.provider';
 
 describe('Application bootstrap', () => {
   it('Should init the app', async () => {

--- a/src/app.provider.ts
+++ b/src/app.provider.ts
@@ -1,6 +1,5 @@
 import { INestApplication, VersioningType } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
-import { TestingModule } from '@nestjs/testing/testing-module';
 
 function configureVersioning(app: INestApplication) {
   app.enableVersioning({
@@ -14,7 +13,7 @@ function configureCors(app: INestApplication) {
   });
 }
 
-const DEFAULT_CONFIGURATION: ((app: INestApplication) => void)[] = [
+export const DEFAULT_CONFIGURATION: ((app: INestApplication) => void)[] = [
   configureVersioning,
   configureCors,
 ];
@@ -55,30 +54,5 @@ export class DefaultAppProvider extends AppProvider {
 
   protected getApp(module: unknown): Promise<INestApplication> {
     return NestFactory.create(module);
-  }
-}
-
-/**
- * A test {@link AppProvider}
- *
- * This provider provides an application given a {@link TestingModule}
- *
- * If the module provided is not a {@link TestingModule}, an error is thrown
- */
-export class TestAppProvider extends AppProvider {
-  protected readonly configuration: Array<(app: INestApplication) => void> =
-    DEFAULT_CONFIGURATION;
-
-  constructor() {
-    super();
-    if (process.env.NODE_ENV !== 'test') {
-      throw Error('TestAppProvider used outside of a testing environment');
-    }
-  }
-
-  protected getApp(module: unknown): Promise<INestApplication> {
-    if (!(module instanceof TestingModule))
-      return Promise.reject(`Provided module is not a TestingModule`);
-    return Promise.resolve(module.createNestApplication());
   }
 }

--- a/src/routes/relay/relay.controller.spec.ts
+++ b/src/routes/relay/relay.controller.spec.ts
@@ -40,8 +40,8 @@ import {
   ISafeInfoService,
   SafeInfoService,
 } from '../../datasources/safe-info/safe-info.service.interface';
-import { TestAppProvider } from '../../app.provider';
 import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
+import { TestAppProvider } from '../../__tests__/test-app.provider';
 
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const GOERLI_MULTI_SEND_CALL_ONLY_ADDRESS = getMultiSendCallOnlyDeployment({


### PR DESCRIPTION
- Extracts `TestAppProvider` to a different file (under `src/__tests__`)
- This change removes the direct reference from `app.provider.ts` (used in production code) to `@nestjs/testing`