### PR TITLE
fix: reduce severity of rate limit breach logging

### DIFF
--- a/src/routes/relay/relay.service.ts
+++ b/src/routes/relay/relay.service.ts
@@ -36,7 +36,7 @@ export class RelayService {
 
     // Check rate limit is not reached
     if (!canRelay) {
-      this.loggingService.error(
+      this.loggingService.warn(
         'Transaction can not be relayed because the address relay limit was reached.',
       );
       throw new HttpException(


### PR DESCRIPTION
This reduces the severity of breached rate limit logs in order to prevent unnecessary Datadog warnings.