### PR TITLE
fix: migrate deprecated faker methods

### DIFF
--- a/src/__mocks__/transaction-calldata.mock.ts
+++ b/src/__mocks__/transaction-calldata.mock.ts
@@ -92,13 +92,13 @@ export function getMockExecTransactionCalldata({
 export function getMockAddOwnerWithThresholdCalldata() {
   return safeInterface.encodeFunctionData('addOwnerWithThreshold', [
     faker.finance.ethereumAddress(),
-    faker.datatype.number(),
+    faker.number.int(),
   ]);
 }
 
 export function getMockChangeThresholdCalldata() {
   return safeInterface.encodeFunctionData('changeThreshold', [
-    faker.datatype.number(),
+    faker.number.int(),
   ]);
 }
 
@@ -170,7 +170,7 @@ export function getMockCreateProxyWithNonceCalldata({
   owners,
   threshold,
   singleton,
-  saltNonce = faker.datatype.number(),
+  saltNonce = faker.number.int(),
 }: {
   owners: string[];
   threshold: number;

--- a/src/datasources/cache/__tests__/fake.cache.service.spec.ts
+++ b/src/datasources/cache/__tests__/fake.cache.service.spec.ts
@@ -10,8 +10,8 @@ describe('FakeCacheService', () => {
   });
 
   it('sets and gets keys', async () => {
-    const key = faker.random.alphaNumeric();
-    const value = faker.random.alphaNumeric();
+    const key = faker.string.alphanumeric();
+    const value = faker.string.alphanumeric();
 
     await cache.set(key, value);
     expect(cache.keyCount()).toBe(1);
@@ -22,8 +22,8 @@ describe('FakeCacheService', () => {
   it('sets keys with expiration', async () => {
     jest.useFakeTimers();
 
-    const key = faker.random.alphaNumeric();
-    const value = faker.random.alphaNumeric();
+    const key = faker.string.alphanumeric();
+    const value = faker.string.alphanumeric();
     const ttl = faker.datatype.number();
 
     await cache.set(key, value, ttl);

--- a/src/datasources/cache/redis.cache.service.spec.ts
+++ b/src/datasources/cache/redis.cache.service.spec.ts
@@ -22,7 +22,7 @@ describe('RedisCacheService', () => {
 
   it('sets keys', async () => {
     const address = faker.finance.ethereumAddress();
-    const value = faker.random.alphaNumeric();
+    const value = faker.string.alphanumeric();
 
     await redisCacheService.set(address, value);
 
@@ -34,7 +34,7 @@ describe('RedisCacheService', () => {
 
   it('sets keys with expiration', async () => {
     const address = faker.finance.ethereumAddress();
-    const value = faker.random.alphaNumeric();
+    const value = faker.string.alphanumeric();
     const ttl = faker.datatype.number();
 
     await redisCacheService.set(address, value, ttl);
@@ -44,7 +44,7 @@ describe('RedisCacheService', () => {
   });
 
   it('gets keys via get', async () => {
-    const key = faker.random.alphaNumeric();
+    const key = faker.string.alphanumeric();
 
     await redisCacheService.get(key);
 

--- a/src/datasources/network/axios.network.service.spec.ts
+++ b/src/datasources/network/axios.network.service.spec.ts
@@ -19,7 +19,7 @@ describe('AxiosNetworkService', () => {
 
   describe('GET requests', () => {
     it('get calls axios get', async () => {
-      const url = faker.internet.url();
+      const url = faker.internet.url({ appendSlash: false });
 
       await target.get(url);
 
@@ -30,8 +30,8 @@ describe('AxiosNetworkService', () => {
 
   describe('POST requests', () => {
     it('post calls axios post', async () => {
-      const url = faker.internet.url();
-      const data = { [faker.random.word()]: faker.random.alphaNumeric() };
+      const url = faker.internet.url({ appendSlash: false });
+      const data = { [faker.word.sample()]: faker.string.alphanumeric() };
 
       await target.post(url, data);
 

--- a/src/datasources/safe-info/gateway.safe-info.service.spec.ts
+++ b/src/datasources/safe-info/gateway.safe-info.service.spec.ts
@@ -10,7 +10,7 @@ describe('GatewaySafeInfoService', () => {
   });
 
   const mockConfigService = new ConfigService({
-    gatewayUrl: faker.internet.url(),
+    gatewayUrl: faker.internet.url({ appendSlash: false }),
   });
 
   const safeInfoService = new GatewaySafeInfoService(

--- a/src/routes/relay/relay.controller.spec.ts
+++ b/src/routes/relay/relay.controller.spec.ts
@@ -92,8 +92,8 @@ describe('RelayController', () => {
               },
               gelato: {
                 apiKey: {
-                  [SupportedChainId.GOERLI]: faker.random.word(),
-                  [SupportedChainId.GNOSIS_CHAIN]: faker.random.word(),
+                  [SupportedChainId.GOERLI]: faker.word.sample(),
+                  [SupportedChainId.GNOSIS_CHAIN]: faker.word.sample(),
                 },
               },
             }),


### PR DESCRIPTION
This migrates deprecated `faker` methods to remove warnings from tests.

- `faker.datatype.number` -> `faker.number.int`
- `faker.random.alphaNumeric` -> `faker.string.alphanumeric`
- `faker.random.word` -> `faker.word.sample`

It also improves the stability of `faker.internet.url` by explicitly settings the appended slash preference.