### PR TITLE
Pin supported safe version

### DIFF
--- a/src/routes/relay/constants.ts
+++ b/src/routes/relay/constants.ts
@@ -1,0 +1,2 @@
+// The service currently only supports safes with a master copy version of 1.3.0
+export const SUPPORTED_SAFE_VERSION = '1.3.0';

--- a/src/routes/relay/entities/schema/transactions/create-proxy-with-nonce.ts
+++ b/src/routes/relay/entities/schema/transactions/create-proxy-with-nonce.ts
@@ -9,6 +9,7 @@ import {
   Gnosis_safe__factory,
   Proxy_factory__factory,
 } from '../../../../../contracts/safe/factories/v1.3.0';
+import { SUPPORTED_SAFE_VERSION } from '../../../constants';
 
 const proxyFactoryInterface = Proxy_factory__factory.createInterface();
 
@@ -72,6 +73,7 @@ export const isValidCreateProxyWithNonceCall = (
   }
 
   const proxyFactoryDeployment = getProxyFactoryDeployment({
+    version: SUPPORTED_SAFE_VERSION,
     network: chainId,
   });
 
@@ -85,9 +87,11 @@ export const isValidCreateProxyWithNonceCall = (
   );
 
   const safeL1Deployment = getSafeSingletonDeployment({
+    version: SUPPORTED_SAFE_VERSION,
     network: chainId,
   });
   const safeL2Deployment = getSafeL2SingletonDeployment({
+    version: SUPPORTED_SAFE_VERSION,
     network: chainId,
   });
 

--- a/src/routes/relay/entities/schema/transactions/multi-send.ts
+++ b/src/routes/relay/entities/schema/transactions/multi-send.ts
@@ -3,6 +3,7 @@ import { getMultiSendCallOnlyDeployment } from '@safe-global/safe-deployments';
 
 import { Multi_send__factory } from '../../../../../contracts/safe/factories/v1.3.0';
 import { isValidExecTransactionCall } from './exec-transaction';
+import { SUPPORTED_SAFE_VERSION } from '../../../constants';
 
 const multiSendInterface = Multi_send__factory.createInterface();
 
@@ -36,6 +37,7 @@ export const isValidMultiSendCall = (
   }
 
   const multiSendLib = getMultiSendCallOnlyDeployment({
+    version: SUPPORTED_SAFE_VERSION,
     network: chainId,
   });
 

--- a/src/routes/relay/entities/schema/transactions/safe.ts
+++ b/src/routes/relay/entities/schema/transactions/safe.ts
@@ -1,9 +1,10 @@
 import { ethers } from 'ethers';
 import {
-  SingletonDeployment,
   getSafeL2SingletonDeployment,
   getSafeSingletonDeployment,
+  SingletonDeployment,
 } from '@safe-global/safe-deployments';
+import { SUPPORTED_SAFE_VERSION } from '../../../constants';
 
 /**
  * Checks whether data is a call to any method in the specified singleton
@@ -33,8 +34,12 @@ const isSingletonCalldata = (
  * @returns boolean
  */
 export const isSafeCalldata = (data: string): boolean => {
-  const safeL1Deployment = getSafeSingletonDeployment();
-  const safeL2Deployment = getSafeL2SingletonDeployment();
+  const safeL1Deployment = getSafeSingletonDeployment({
+    version: SUPPORTED_SAFE_VERSION,
+  });
+  const safeL2Deployment = getSafeL2SingletonDeployment({
+    version: SUPPORTED_SAFE_VERSION,
+  });
 
   if (!safeL1Deployment || !safeL2Deployment) {
     return false;

--- a/src/routes/relay/relay.controller.spec.ts
+++ b/src/routes/relay/relay.controller.spec.ts
@@ -17,17 +17,17 @@ import { SupportedChainId } from '../../config/constants';
 import {
   getMockAddOwnerWithThresholdCalldata,
   getMockChangeThresholdCalldata,
+  getMockCreateProxyWithNonceCalldata,
   getMockDisableModuleCalldata,
   getMockEnableModuleCalldata,
-  getMockCreateProxyWithNonceCalldata,
+  getMockErc20TransferCalldata,
   getMockExecTransactionCalldata,
   getMockMultiSendCalldata,
-  getMockSetFallbackHandlerCalldata,
   getMockRemoveOwnerCallData,
+  getMockSetFallbackHandlerCalldata,
   getMockSetGuardCalldata,
   getMockSwapOwnerCallData,
   MOCK_UNSUPPORTED_CALLDATA,
-  getMockErc20TransferCalldata,
 } from '../../__mocks__/transaction-calldata.mock';
 import { TestLoggingModule } from '../common/logging/__tests__/test.logging.module';
 import { TestSponsorModule } from '../../datasources/sponsor/__tests__/test.sponsor.module';
@@ -42,24 +42,29 @@ import {
 } from '../../datasources/safe-info/safe-info.service.interface';
 import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
 import { TestAppProvider } from '../../__tests__/test-app.provider';
+import { SUPPORTED_SAFE_VERSION } from './constants';
 
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const GOERLI_MULTI_SEND_CALL_ONLY_ADDRESS = getMultiSendCallOnlyDeployment({
+  version: SUPPORTED_SAFE_VERSION,
   network: '5',
 })!.defaultAddress;
 
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const GOERLI_L1_SINGLETON_DEPLOYMENT_ADDRESS = getSafeSingletonDeployment({
+  version: SUPPORTED_SAFE_VERSION,
   network: '5',
 })!.defaultAddress;
 
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const GOERLI_L2_SINGLETON_DEPLOYMENT_ADDRESS = getSafeL2SingletonDeployment({
+  version: SUPPORTED_SAFE_VERSION,
   network: '5',
 })!.defaultAddress;
 
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const GOERLI_PROXY_FACTORY_DEPLOYMENT_ADDRESS = getProxyFactoryDeployment({
+  version: SUPPORTED_SAFE_VERSION,
   network: '5',
 })!.defaultAddress;
 


### PR DESCRIPTION
- Pins 1.3.0 as the supported master copy version to use with the service.
- By pinning the version, we avoid situations where the default version changes on `@safe-global/safe-deployments` (and not being supported by this service).