### PR TITLE
Fix lock file

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -8443,13 +8443,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:2.6.1":
-  version: 2.6.1
-  resolution: "tslib@npm:2.6.1"
-  checksum: b0d176d176487905b66ae4d5856647df50e37beea7571c53b8d10ba9222c074b81f1410fb91da13debaf2cbc970663609068bdebafa844ea9d69b146527c38fe
-  languageName: node
-  linkType: hard
-
 "tslib@npm:2.6.2":
   version: 2.6.2
   resolution: "tslib@npm:2.6.2"


### PR DESCRIPTION
Removes `tslib@npm:2.6.1` from yarn.lock – this dependency is no longer needed and is preventing the Yarn installation step to successfully complete.

This was most likely caused by a conflict in merging the recent dependency updates.