### PR TITLE
Add Sepolia to supported chains

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,16 +32,19 @@ corepack enable && yarn install
 Before running the service you need to set up a Gelato API Key – https://docs.gelato.network/developer-services/relay/payment-and-fees/1balance#production.
 This can be added via an environment variable in the local environment where you are executing the service:
 
-Currently two chains are supported: Goerli (chainId=5) and Gnosis Chain (chainId=100).
+Currently three chains are supported: Goerli (chainId=5), Gnosis Chain (chainId=100) and Sepolia (chainId=11155111).
 ```bash
 # To configure Goerli
 export GELATO_GOERLI_API_KEY=<GOERLI_GELATO_API_KEY>
 
 # To configure Gnosis Chain
 export GELATO_GNOSIS_CHAIN_API_KEY=<GNOSIS_GELATO_API_KEY>
+
+# To configure Sepolia
+export GELATO_SEPOLIA_API_KEY=<SEPOLIA_GELATO_API_KEY>
 ```
 
-Both chains can be configured simultaneously.
+All the chains can be configured simultaneously.
 
 ---
 

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -17,6 +17,7 @@ export default () => ({
     apiKey: {
       [SupportedChainId.GOERLI]: process.env.GELATO_GOERLI_API_KEY,
       [SupportedChainId.GNOSIS_CHAIN]: process.env.GELATO_GNOSIS_CHAIN_API_KEY,
+      [SupportedChainId.SEPOLIA]: process.env.GELATO_SEPOLIA_API_KEY,
     },
   },
   gatewayUrl: process.env.GATEWAY_URL || 'https://safe-client.safe.global',

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,4 +1,5 @@
 export enum SupportedChainId {
   GOERLI = '5',
   GNOSIS_CHAIN = '100',
+  SEPOLIA = '11155111',
 }


### PR DESCRIPTION
Sepolia is now enabled on the Gelato side but this service has hardcoded configs that prevent us from using it directly on the frontend.

Example URL:
https://safe-client.staging.5afe.dev/v1/relay/11155111/0x0fF7Bd21350ccf2849c828E4eABEC45Ad275C0e7

We might want to consider fetching the config-service feature toggle (`RELAYING`) instead of the static config, or removing the chain id validation altogether.