### PR TITLE
Refactor: type-check API keys to avoid missing configs

### DIFF
--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -1,5 +1,11 @@
 import { SupportedChainId } from './constants';
 
+const API_KEYS: Record<SupportedChainId, string | undefined> = {
+  [SupportedChainId.GOERLI]: process.env.GELATO_GOERLI_API_KEY,
+  [SupportedChainId.GNOSIS_CHAIN]: process.env.GELATO_GNOSIS_CHAIN_API_KEY,
+  [SupportedChainId.SEPOLIA]: process.env.GELATO_SEPOLIA_API_KEY,
+};
+
 export default () => ({
   about: {
     name: 'safe-gelato-relay-service',
@@ -14,11 +20,7 @@ export default () => ({
     limit: process.env.THROTTLE_LIMIT ? +process.env.THROTTLE_LIMIT : 5,
   },
   gelato: {
-    apiKey: {
-      [SupportedChainId.GOERLI]: process.env.GELATO_GOERLI_API_KEY,
-      [SupportedChainId.GNOSIS_CHAIN]: process.env.GELATO_GNOSIS_CHAIN_API_KEY,
-      [SupportedChainId.SEPOLIA]: process.env.GELATO_SEPOLIA_API_KEY,
-    },
+    apiKey: API_KEYS,
   },
   gatewayUrl: process.env.GATEWAY_URL || 'https://safe-client.safe.global',
 });


### PR DESCRIPTION
The build will fail if an API key for one of the supported chains isn't provided.

<img width="1091" alt="Screenshot 2023-11-27 at 14 10 26" src="https://github.com/safe-global/safe-gelato-relay-service/assets/381895/f68f929a-e511-4297-a4c5-a313b22f8c8a">
