### PR TITLE
Bump node version from 18 to 20.10.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: '20.10.x'
           cache: 'yarn'
       - run: yarn install --immutable
       - run: yarn run format-check
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: '20.10.x'
           cache: 'yarn'
       - run: yarn install --immutable
       - run: yarn run lint-check
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: '20.10.x'
           cache: 'yarn'
       - run: yarn install --immutable
       - run: yarn run build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # BUILD CONTAINER
 #
-FROM node:18 as base
+FROM node:20.10.0 as base
 ENV NODE_ENV production
 WORKDIR /app
 COPY --chown=node:node .yarn/releases ./.yarn/releases
@@ -14,7 +14,7 @@ RUN yarn run build
 #
 # PRODUCTION CONTAINER
 #
-FROM node:18-alpine as production
+FROM node:20.10.0-alpine as production
 USER node
 
 ARG VERSION

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Development images are currently being published to [Docker Hub](https://hub.doc
 
 ## Requirements
 
-- Node 18 (LTS) – https://nodejs.org/en/
+- Node 20.10 (LTS) – https://nodejs.org/en/
 - Gelato's 1Balance API key – https://docs.gelato.network/developer-services/relay/payment-and-fees/1balance#production 
 
 ## Installation


### PR DESCRIPTION
Bumps the node version from 18 to 20.10.0 (current LTS). 
Changelog: https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V20.md#20.10.0