### PR TITLE
Add VERSION and BUILD_NUMBER args

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - run: |
+          BUILD_NUMBER=${{ github.sha }}
+          echo "BUILD_NUMBER=${BUILD_NUMBER::7}" >> "$GITHUB_ENV"
       - uses: docker/setup-qemu-action@v3.0.0
         with:
           platforms: arm64
@@ -73,6 +76,9 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
           push: true
+          build-args: |
+            BUILD_NUMBER=${{ env.BUILD_NUMBER }}
+            VERSION=${{ github.ref_name }}
           tags: ${{ env.DOCKER_IMAGE_TAG }}
           # Use inline cache storage https://docs.docker.com/build/cache/backends/inline/
           cache-from: type=registry,ref=${{ env.DOCKER_IMAGE_TAG }}
@@ -84,6 +90,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - run: |
+          BUILD_NUMBER=${{ github.sha }}
+          echo "BUILD_NUMBER=${BUILD_NUMBER::7}" >> "$GITHUB_ENV"
       - uses: docker/setup-qemu-action@v3.0.0
         with:
           platforms: arm64
@@ -96,6 +105,9 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
           push: true
+          build-args: |
+            BUILD_NUMBER=${{ env.BUILD_NUMBER }}
+            VERSION=${{ github.ref_name }}
           tags: |
             safeglobal/safe-gelato-relay-service:${{ github.event.release.tag_name }}
             safeglobal/safe-gelato-relay-service:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,13 @@ RUN yarn run build
 #
 FROM node:18-alpine as production
 USER node
+
+ARG VERSION
+ARG BUILD_NUMBER
+
+ENV APPLICATION_VERSION=${VERSION} \
+    APPLICATION_BUILD_NUMBER=${BUILD_NUMBER}
+
 COPY --chown=node:node --from=base /app/node_modules ./node_modules
 COPY --chown=node:node --from=base /app/dist ./dist
 CMD [ "node", "dist/main.js" ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "safe-gelato-relay-service",
-  "version": "0.14.0",
   "description": "",
   "author": "",
   "private": true,

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -9,6 +9,8 @@ const API_KEYS: Record<SupportedChainId, string | undefined> = {
 export default () => ({
   about: {
     name: 'safe-gelato-relay-service',
+    version: process.env.APPLICATION_VERSION,
+    buildNumber: process.env.APPLICATION_BUILD_NUMBER,
   },
   applicationPort: process.env.APPLICATION_PORT || '3000',
   redis: {


### PR DESCRIPTION
- The provided docker image now requires a `VERSION` and `BUILD_NUMBER` to be set. These are provided as build arguments to the image – https://docs.docker.com/engine/reference/builder/#arg
- The `BUILD_NUMBER` will be the first seven characters of the commit hash that triggered the build.
- The `VERSION` will be the `ref_name` of the commit that triggered the build. For a branch, that will be the branch name (e.g.: `main`) and for a release it will be the release tag.